### PR TITLE
Ensure XmlReader does not throw exception when (external) DTD is included

### DIFF
--- a/Aikido.Zen.Core/Helpers/HttpHelper.cs
+++ b/Aikido.Zen.Core/Helpers/HttpHelper.cs
@@ -202,7 +202,7 @@ namespace Aikido.Zen.Core.Helpers
                     }
                     else if (section.ContentType == "application/xml" || section.ContentType == "text/xml")
                     {
-                        using (var xmlReader = XmlReader.Create(section.Body, new XmlReaderSettings { Async = true }))
+                        using (var xmlReader = XmlReader.Create(section.Body, new XmlReaderSettings { Async = true, DtdProcessing = DtdProcessing.Ignore }))
                         {
                             var xmlDoc = new XmlDocument();
                             xmlDoc.Load(xmlReader);


### PR DESCRIPTION
This also ensures that (external) DTDs are not processed, although `Prohibit` has been the default since recent .NET framework versions.