### PR TITLE
version downgrade (unlisted version)

### DIFF
--- a/Aikido.Zen.DotNetFramework/Aikido.Zen.DotNetFramework.csproj
+++ b/Aikido.Zen.DotNetFramework/Aikido.Zen.DotNetFramework.csproj
@@ -112,8 +112,8 @@
     <Reference Include="Microsoft.IdentityModel.Tokens, Version=6.35.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Tokens.6.35.0\lib\net472\Microsoft.IdentityModel.Tokens.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Web.Infrastructure, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Web.Infrastructure.2.0.1\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.2.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="MySql.Data, Version=9.1.0.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
       <HintPath>..\packages\MySql.Data.9.1.0\lib\net48\MySql.Data.dll</HintPath>

--- a/Aikido.Zen.DotNetFramework/packages.config
+++ b/Aikido.Zen.DotNetFramework/packages.config
@@ -27,7 +27,7 @@
   <package id="Microsoft.IdentityModel.Protocols" version="6.35.0" targetFramework="net48" />
   <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.35.0" targetFramework="net48" />
   <package id="Microsoft.IdentityModel.Tokens" version="6.35.0" targetFramework="net48" />
-  <package id="Microsoft.Web.Infrastructure" version="2.0.1" targetFramework="net48" />
+  <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net48" />
   <package id="MySql.Data" version="9.1.0" targetFramework="net48" />
   <package id="MySqlConnector" version="2.4.0" targetFramework="net48" />
   <package id="Npgsql" version="4.1.14" targetFramework="net48" />

--- a/sample-apps/DotNetFramework.Sample.App/DotNetFramework.Sample.App.csproj
+++ b/sample-apps/DotNetFramework.Sample.App/DotNetFramework.Sample.App.csproj
@@ -389,9 +389,9 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="Microsoft.Web.Infrastructure, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Web.Infrastructure, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.2.0.1\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.2.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/sample-apps/DotNetFramework.Sample.App/Web.config
+++ b/sample-apps/DotNetFramework.Sample.App/Web.config
@@ -42,7 +42,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Web.Infrastructure" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.1.0" newVersion="2.0.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />

--- a/sample-apps/DotNetFramework.Sample.App/packages.config
+++ b/sample-apps/DotNetFramework.Sample.App/packages.config
@@ -58,7 +58,7 @@
   <package id="Microsoft.IdentityModel.Protocols" version="6.35.0" targetFramework="net48" />
   <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.35.0" targetFramework="net48" />
   <package id="Microsoft.IdentityModel.Tokens" version="6.35.0" targetFramework="net48" />
-  <package id="Microsoft.Web.Infrastructure" version="2.0.1" targetFramework="net48" />
+  <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net48" />
   <package id="Microsoft.Win32.Registry" version="5.0.0" targetFramework="net48" />
   <package id="Modernizr" version="2.8.3" targetFramework="net48" />
   <package id="MySql.Data" version="9.1.0" targetFramework="net48" />


### PR DESCRIPTION
Fix for [Issue 64](https://github.com/AikidoSec/firewall-dotnet/issues/62): downgrade Microsoft.Web.Infrastructure to Version 2.0.0 since 2.0.1is unlisted.