### PR TITLE
Ignore .well-known routes if not actual well known URI

### DIFF
--- a/Aikido.Zen.Core/Helpers/RouteHelper.cs
+++ b/Aikido.Zen.Core/Helpers/RouteHelper.cs
@@ -6,12 +6,101 @@ namespace Aikido.Zen.Core.Helpers
 {
     public static class RouteHelper
     {
-
-
         private static readonly string[] ExcludedMethods = { "OPTIONS", "HEAD" };
         private static readonly string[] IgnoreExtensions = { "properties", "php", "asp", "aspx", "jsp", "config" };
         private static readonly string[] IgnoreStrings = { "cgi-bin" };
-
+        private static readonly HashSet<string> WellKnownURIs = new HashSet<string>
+        {
+            "/.well-known/acme-challenge",
+            "/.well-known/amphtml",
+            "/.well-known/api-catalog",
+            "/.well-known/appspecific",
+            "/.well-known/ashrae",
+            "/.well-known/assetlinks.json",
+            "/.well-known/broadband-labels",
+            "/.well-known/brski",
+            "/.well-known/caldav",
+            "/.well-known/carddav",
+            "/.well-known/change-password",
+            "/.well-known/cmp",
+            "/.well-known/coap",
+            "/.well-known/coap-eap",
+            "/.well-known/core",
+            "/.well-known/csaf",
+            "/.well-known/csaf-aggregator",
+            "/.well-known/csvm",
+            "/.well-known/did.json",
+            "/.well-known/did-configuration.json",
+            "/.well-known/dnt",
+            "/.well-known/dnt-policy.txt",
+            "/.well-known/dots",
+            "/.well-known/ecips",
+            "/.well-known/edhoc",
+            "/.well-known/enterprise-network-security",
+            "/.well-known/enterprise-transport-security",
+            "/.well-known/est",
+            "/.well-known/genid",
+            "/.well-known/gnap-as-rs",
+            "/.well-known/gpc.json",
+            "/.well-known/gs1resolver",
+            "/.well-known/hoba",
+            "/.well-known/host-meta",
+            "/.well-known/host-meta.json",
+            "/.well-known/hosting-provider",
+            "/.well-known/http-opportunistic",
+            "/.well-known/idp-proxy",
+            "/.well-known/jmap",
+            "/.well-known/keybase.txt",
+            "/.well-known/knx",
+            "/.well-known/looking-glass",
+            "/.well-known/masque",
+            "/.well-known/matrix",
+            "/.well-known/mercure",
+            "/.well-known/mta-sts.txt",
+            "/.well-known/mud",
+            "/.well-known/nfv-oauth-server-configuration",
+            "/.well-known/ni",
+            "/.well-known/nodeinfo",
+            "/.well-known/nostr.json",
+            "/.well-known/oauth-authorization-server",
+            "/.well-known/oauth-protected-resource",
+            "/.well-known/ohttp-gateway",
+            "/.well-known/openid-federation",
+            "/.well-known/open-resource-discovery",
+            "/.well-known/openid-configuration",
+            "/.well-known/openorg",
+            "/.well-known/oslc",
+            "/.well-known/pki-validation",
+            "/.well-known/posh",
+            "/.well-known/privacy-sandbox-attestations.json",
+            "/.well-known/private-token-issuer-directory",
+            "/.well-known/probing.txt",
+            "/.well-known/pvd",
+            "/.well-known/rd",
+            "/.well-known/related-website-set.json",
+            "/.well-known/reload-config",
+            "/.well-known/repute-template",
+            "/.well-known/resourcesync",
+            "/.well-known/sbom",
+            "/.well-known/security.txt",
+            "/.well-known/ssf-configuration",
+            "/.well-known/sshfp",
+            "/.well-known/stun-key",
+            "/.well-known/terraform.json",
+            "/.well-known/thread",
+            "/.well-known/time",
+            "/.well-known/timezone",
+            "/.well-known/tdmrep.json",
+            "/.well-known/tor-relay",
+            "/.well-known/tpcd",
+            "/.well-known/traffic-advice",
+            "/.well-known/trust.txt",
+            "/.well-known/uma2-configuration",
+            "/.well-known/void",
+            "/.well-known/webfinger",
+            "/.well-known/webweaver.json",
+            "/.well-known/wot",
+        };
 
         /// <summary>
         /// Matches a route pattern against an actual URL path
@@ -119,8 +208,14 @@ namespace Aikido.Zen.Core.Helpers
             // Split the route into segments
             var segments = context.Route.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
 
-            // Check for dot files and ignored strings
-            if (segments.Any(s => IsDotFile(s) && !ContainsIgnoredString(s)))
+            // Do not discover routes with dot files like `/path/to/.file` or `/.directory/file`
+            // We want to allow discovery of well-known URIs like `/.well-known/acme-challenge`
+            if (!IsWellKnownURI(context.Route) && segments.Any(IsDotFile))
+            {
+                return false;
+            }
+
+            if (segments.Any(ContainsIgnoredString))
             {
                 return false;
             }
@@ -145,17 +240,24 @@ namespace Aikido.Zen.Core.Helpers
 
         private static bool IsDotFile(string segment)
         {
-            // See https://www.rfc-editor.org/rfc/rfc8615
-            if (segment == ".well-known")
-            {
-                return false;
-            }
             return segment.StartsWith(".") && segment.Length > 1;
         }
 
         private static bool ContainsIgnoredString(string segment)
         {
             return IgnoreStrings.Any(str => segment.Contains(str));
+        }
+
+        /// <summary>
+        /// Check if a path is a well-known URI
+        /// e.g. /.well-known/acme-challenge
+        /// https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml
+        /// </summary>
+        /// <param name="path">The path to check</param>
+        /// <returns>True if the segment is a well-known URI, false otherwise</returns>
+        private static bool IsWellKnownURI(string path)
+        {
+            return WellKnownURIs.Contains(path);
         }
     }
 }

--- a/Aikido.Zen.Test/RouteHelperTests.cs
+++ b/Aikido.Zen.Test/RouteHelperTests.cs
@@ -2,6 +2,7 @@ using Aikido.Zen.Core;
 using Aikido.Zen.Core.Helpers;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 
 namespace Aikido.Zen.Test.Helpers
 {
@@ -58,7 +59,11 @@ namespace Aikido.Zen.Test.Helpers
         [TestCase("/api/resource", "GET", 200, true)]
         [TestCase("/api/resource", "OPTIONS", 200, false)]
         [TestCase("/api/resource", "GET", 404, false)]
-        [TestCase("/api/.well-known/resource", "GET", 200, true)]
+        [TestCase("/.well-known", "GET", 200, false)]
+        [TestCase("/.well-known/change-password", "GET", 200, true)]
+        [TestCase("/.well-known/security.txt", "GET", 200, false)]
+        [TestCase("/cgi-bin/luci/;stok=/locale", "GET", 200, false)]
+        [TestCase("/whatever/cgi-bin", "GET", 200, false)]
         [TestCase("/api/.hidden/resource", "GET", 200, false)]
         [TestCase("/api/resource.php", "GET", 200, false)]
         [TestCase("/api/resource", "HEAD", 200, false)]


### PR DESCRIPTION
Also found bug in logic regarding `ContainsIgnoredString`

if any segment contains ignored string should return false