### PR TITLE
Check if string is null or empty

### DIFF
--- a/Aikido.Zen.DotNetCore/DependencyInjection.cs
+++ b/Aikido.Zen.DotNetCore/DependencyInjection.cs
@@ -63,14 +63,14 @@ namespace Aikido.Zen.DotNetCore
             var contextAccessor = app.ApplicationServices.GetRequiredService<IHttpContextAccessor>();
             Zen.Initialize(app.ApplicationServices, contextAccessor);
             var options = app.ApplicationServices.GetRequiredService<IOptions<AikidoOptions>>();
-            if (options?.Value?.AikidoToken != null)
+
+            if (!string.IsNullOrEmpty(options?.Value?.AikidoToken))
             {
                 var agent = Agent.NewInstance(app.ApplicationServices.GetRequiredService<IZenApi>());
                 var agentLogger = app.ApplicationServices.GetService<ILogger<Agent>>();
                 if (agentLogger != null)
                 {
                     Agent.ConfigureLogger(agentLogger);
-
                 }
                 agent.Start();
 


### PR DESCRIPTION
The appsettings.json of the sample app contains an empty string:

"Aikido": {
    "AikidoToken": ""
}

If you start the app it will crash:

```
Unhandled exception. System.ArgumentNullException: Value cannot be null. (Parameter 'token')
   at Aikido.Zen.Core.Agent.QueueEvent(String token, IEvent evt, Action`2 callback) in /Users/hansott/Code/firewall-dotnet/Aikido.Zen.Core/Agent.cs:line 145
   at Aikido.Zen.Core.Agent.Start() in /Users/hansott/Code/firewall-dotnet/Aikido.Zen.Core/Agent.cs:line 102
   at Aikido.Zen.DotNetCore.DependencyInjection.UseZenFirewall(IApplicationBuilder app) in /Users/hansott/Code/firewall-dotnet/Aikido.Zen.DotNetCore/DependencyInjection.cs:line 71
   at Program.<Main>$(String[] args) in /Users/hansott/Code/firewall-dotnet/sample-apps/DotNetCore.Sample.App/Program.cs:line 16
```