### PR TITLE
Catch "The method or operation is not implemented" exception

### DIFF
--- a/Aikido.Zen.Core/Patches/HttpClientPatches.cs
+++ b/Aikido.Zen.Core/Patches/HttpClientPatches.cs
@@ -24,7 +24,7 @@ namespace Aikido.Zen.Core.Patches
             catch (NotImplementedException e)
             {
                 // pass through, there may be some methods that are not implemented
-                Console.WriteLine("Aikido: error patching HttpClient:" + e.Message);
+                Console.WriteLine("Aikido: error patching HttpClient: " + e.Message);
             }
 
         }

--- a/Aikido.Zen.DotNetCore/Patches/IOPatches.cs
+++ b/Aikido.Zen.DotNetCore/Patches/IOPatches.cs
@@ -1,6 +1,7 @@
 using Aikido.Zen.Core.Exceptions;
 using Aikido.Zen.Core.Helpers;
 using HarmonyLib;
+using System;
 using System.Diagnostics;
 using System.Net;
 using System.Security.AccessControl;
@@ -29,13 +30,12 @@ namespace Aikido.Zen.DotNetCore.Patches
             // Directory operations
             PatchMethod(harmony, typeof(Directory), "CreateDirectory", new[] { typeof(string), typeof(DirectorySecurity) });
             PatchMethod(harmony, typeof(Directory), "Delete", new[] { typeof(string), typeof(bool) });
-            PatchMethod(harmony, typeof(Directory), "GetFiles", new[] { typeof(string)  });
+            PatchMethod(harmony, typeof(Directory), "GetFiles", new[] { typeof(string) });
             PatchMethod(harmony, typeof(Directory), "GetFiles", new[] { typeof(string), typeof(string) });
             PatchMethod(harmony, typeof(Directory), "GetFiles", new[] { typeof(string), typeof(string), typeof(SearchOption) });
             PatchMethod(harmony, typeof(Directory), "GetDirectories", new[] { typeof(string) });
             PatchMethod(harmony, typeof(Directory), "GetDirectories", new[] { typeof(string), typeof(string) });
             PatchMethod(harmony, typeof(Directory), "GetDirectories", new[] { typeof(string), typeof(string), typeof(SearchOption) });
-
         }
 
         private static void PatchMethod(Harmony harmony, Type type, string methodName, Type[] parameters = null)
@@ -54,9 +54,12 @@ namespace Aikido.Zen.DotNetCore.Patches
                 }
 
             }
+            catch (NotImplementedException e)
+            {
+                Console.WriteLine("Aikido: error patching " + methodName + " method: " + e.Message);
+            }
             catch (Exception e)
             {
-
                 throw;
             }
         }


### PR DESCRIPTION
```
Unhandled exception. System.NotImplementedException: The method or operation is not implemented.
at HarmonyLib.PatchFunctions.UpdateWrapper(MethodBase original, PatchInfo patchInfo)
   at HarmonyLib.PatchProcessor.Patch()
   at HarmonyLib.Harmony.Patch(MethodBase original, HarmonyMethod prefix, HarmonyMethod postfix, HarmonyMethod transpiler, HarmonyMethod finalizer)
   at Aikido.Zen.DotNetCore.Patches.IOPatches.PatchMethod(Harmony harmony, Type type, String methodName, Type[] parameters) in /Users/hansott/Code/firewall-dotnet/Aikido.Zen.DotNetCore/Patches/IOPatches.cs:line 51
   at Aikido.Zen.DotNetCore.Patches.IOPatches.ApplyPatches(Harmony harmony) in /Users/hansott/Code/firewall-dotnet/Aikido.Zen.DotNetCore/Patches/IOPatches.cs:line 16
   at Aikido.Zen.DotNetCore.Patches.Patcher.Patch() in /Users/hansott/Code/firewall-dotnet/Aikido.Zen.DotNetCore/Patches/Patcher.cs:line 17
   at Aikido.Zen.DotNetCore.DependencyInjection.UseZenFirewall(IApplicationBuilder app) in /Users/hansott/Code/firewall-dotnet/Aikido.Zen.DotNetCore/DependencyInjection.cs:line 79
```

Only on macOS using .NET 8