### PR TITLE
Started timestamp fix

### DIFF
--- a/Aikido.Zen.Core/Models/AgentContext.cs
+++ b/Aikido.Zen.Core/Models/AgentContext.cs
@@ -1,13 +1,13 @@
-using Aikido.Zen.Core.Api;
-using Aikido.Zen.Core.Helpers;
-using Aikido.Zen.Core.Helpers.OpenAPI;
-using Aikido.Zen.Core.Models.Ip;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Aikido.Zen.Core.Api;
+using Aikido.Zen.Core.Helpers;
+using Aikido.Zen.Core.Helpers.OpenAPI;
+using Aikido.Zen.Core.Models.Ip;
 
 namespace Aikido.Zen.Core.Models
 {
@@ -30,7 +30,7 @@ namespace Aikido.Zen.Core.Models
         private int _attacksDetected;
         private int _attacksBlocked;
         private int _requestsAborted;
-        private readonly long _started = DateTimeHelper.UTCNowUnixMilliseconds();
+        private long _started = DateTimeHelper.UTCNowUnixMilliseconds();
         public long ConfigLastUpdated { get; set; } = 0;
         public bool ContextMiddlewareInstalled { get; set; } = false;
         public bool BlockingMiddlewareInstalled { get; set; } = false;
@@ -143,6 +143,8 @@ namespace Aikido.Zen.Core.Models
             Interlocked.Exchange(ref _attacksBlocked, 0);
             Interlocked.Exchange(ref _requestsAborted, 0);
             _blockedUsers.Clear();
+            // reset the started time
+            _started = DateTimeHelper.UTCNowUnixMilliseconds();
         }
 
         public bool IsBlocked(Context context, out string reason)

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -1,10 +1,9 @@
 using Aikido.Zen.Core;
 using Aikido.Zen.Core.Api;
-using Aikido.Zen.Core.Helpers;
 using Aikido.Zen.Core.Models;
 using Aikido.Zen.Core.Models.Events;
-using Moq;
 using Aikido.Zen.Tests.Mocks;
+using Moq;
 
 namespace Aikido.Zen.Test
 {
@@ -30,7 +29,7 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public void ClearContext_ResetsAllContextValues()
+        public async Task ClearContext_ResetsAllContextValues()
         {
             // Arrange
             var context = new Context
@@ -43,8 +42,12 @@ namespace Aikido.Zen.Test
             _agent.CaptureRequestUser(context);
             _agent.IncrementTotalRequestCount();
             _agent.CaptureOutboundRequest("test.com", 443);
+            var startedTime = _agent.Context.Started;
 
             // Act
+            // wait a bit to make sure some ms have passed between settings the started time and clearing the context
+            var waitTimeMs = 25;
+            await Task.Delay(waitTimeMs);
             _agent.ClearContext();
 
             // Assert
@@ -52,6 +55,7 @@ namespace Aikido.Zen.Test
             Assert.That(_agent.Context.Routes.Count, Is.EqualTo(0));
             Assert.That(_agent.Context.Hostnames.Count, Is.EqualTo(0));
             Assert.That(_agent.Context.Requests, Is.EqualTo(0));
+            Assert.That(_agent.Context.Started, Is.GreaterThanOrEqualTo(startedTime + waitTimeMs));
         }
 
         [Test]


### PR DESCRIPTION
The Started timestamp in the agent context is now reset everytime a heartbeat is sent to the server, ensuring correct stat times.