### PR TITLE
Route matching improvements

### DIFF
--- a/Aikido.Zen.Core/Helpers/RouteHelper.cs
+++ b/Aikido.Zen.Core/Helpers/RouteHelper.cs
@@ -277,6 +277,17 @@ namespace Aikido.Zen.Core.Helpers
         }
 
         /// <summary>
+        /// Checks if a path is a single segment
+        /// </summary>
+        /// <param name="path">The path to check</param>
+        /// <returns>True if the path is a single segment, false otherwise</returns>
+        public static bool PathIsSingleSegment(string path)
+        {
+            var segments = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            return segments.Length <=1;
+        }
+
+        /// <summary>
         /// Matches a context against a list of endpoints, finding all matching endpoints
         /// </summary>
         /// <param name="context">The context containing request information</param>

--- a/Aikido.Zen.Core/Helpers/RouteParameterHelper.cs
+++ b/Aikido.Zen.Core/Helpers/RouteParameterHelper.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Net;
+using System.Text.RegularExpressions;
 
 namespace Aikido.Zen.Core.Helpers
 {
@@ -111,6 +111,34 @@ namespace Aikido.Zen.Core.Helpers
 
             var averageRatio = ratios.Average();
             return averageRatio > 0.75;
+        }
+
+        /// <summary>
+        /// Determines if a path is a single route parameter
+        /// This sometimes happens in applications that use one route to handle all requests e.g. /{slug}
+        /// Resulting in a lot of routes getting aggregated under the same route.
+        /// </summary>
+        /// <param name="path">The path to check</param>
+        /// <returns>True if the path is a single route parameter, false otherwise</returns>
+        public static bool PathIsSingleRouteParameter(string path)
+        {
+            // regex to detect if the path starts with a parameter
+            var regex = new Regex(@"(\{[^\}]+\})|:uuid|:ulid|:objectId|:email|:hash|:secret|:number|:date", RegexOptions.Compiled);
+            var apiPrefix = new Regex(@"^/api(/v\d+)?", RegexOptions.Compiled);
+            // remove the api prefix
+            var pathWithoutApiPrefix = apiPrefix.Replace(path, string.Empty);
+
+            // If there are multiple slashes, it's not a single route parameter
+            if (pathWithoutApiPrefix.Count(c => c == '/') > 1)
+                return false;
+
+            // Check if the path starts with a slash and has content after it
+            if (pathWithoutApiPrefix.StartsWith("/") && pathWithoutApiPrefix.Length > 1)
+            {
+                string pathAfterFirstSlash = pathWithoutApiPrefix.Substring(1);
+                return regex.IsMatch(pathAfterFirstSlash);
+            }
+            return regex.IsMatch(pathWithoutApiPrefix);
         }
 
         private static string ReplaceUrlSegmentWithParam(string segment)

--- a/Aikido.Zen.Core/Helpers/RouteParameterHelper.cs
+++ b/Aikido.Zen.Core/Helpers/RouteParameterHelper.cs
@@ -113,34 +113,6 @@ namespace Aikido.Zen.Core.Helpers
             return averageRatio > 0.75;
         }
 
-        /// <summary>
-        /// Determines if a path is a single route parameter
-        /// This sometimes happens in applications that use one route to handle all requests e.g. /{slug}
-        /// Resulting in a lot of routes getting aggregated under the same route.
-        /// </summary>
-        /// <param name="path">The path to check</param>
-        /// <returns>True if the path is a single route parameter, false otherwise</returns>
-        public static bool PathIsSingleRouteParameter(string path)
-        {
-            // regex to detect if the path starts with a parameter
-            var regex = new Regex(@"(\{[^\}]+\})|:uuid|:ulid|:objectId|:email|:hash|:secret|:number|:date", RegexOptions.Compiled);
-            var apiPrefix = new Regex(@"^/api(/v\d+)?", RegexOptions.Compiled);
-            // remove the api prefix
-            var pathWithoutApiPrefix = apiPrefix.Replace(path, string.Empty);
-
-            // If there are multiple slashes, it's not a single route parameter
-            if (pathWithoutApiPrefix.Count(c => c == '/') > 1)
-                return false;
-
-            // Check if the path starts with a slash and has content after it
-            if (pathWithoutApiPrefix.StartsWith("/") && pathWithoutApiPrefix.Length > 1)
-            {
-                string pathAfterFirstSlash = pathWithoutApiPrefix.Substring(1);
-                return regex.IsMatch(pathAfterFirstSlash);
-            }
-            return regex.IsMatch(pathWithoutApiPrefix);
-        }
-
         private static string ReplaceUrlSegmentWithParam(string segment)
         {
             if (string.IsNullOrEmpty(segment))

--- a/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
@@ -113,9 +113,15 @@ namespace Aikido.Zen.DotNetCore.Middleware
             // Use the .NET core route collection to match against the request path,
             // ensuring the routes found by Zen match those found by the .NET core
             var routePattern = context.Request.Path.Value;
+
             if (context.Request.Path == null)
             {
-                return string.Empty;
+                return "/";
+            }
+
+            if (RouteHelper.PathIsSingleSegment(context.Request.Path.Value))
+            {
+                return "/" + context.Request.Path.Value.TrimStart('/');
             }
 
             // Find the most exact endpoint that matches the request path
@@ -149,14 +155,14 @@ namespace Aikido.Zen.DotNetCore.Middleware
                 }
             }
 
-            // Override with raw path if it's a single route parameter
-            if (RouteParameterHelper.PathIsSingleRouteParameter(routePattern))
+            // Add a leading slash to the route pattern if not present
+            // Ensure route pattern starts with a slash and handle null case
+            if (string.IsNullOrEmpty(routePattern))
             {
-                routePattern = context.Request.Path.Value;
+                return "/";
             }
 
-            // Add a leading slash to the route pattern if not present
-            return routePattern != null ? "/" + routePattern.TrimStart('/') : string.Empty;
+            return "/" + routePattern.TrimStart('/');
         }
     }
 }

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -138,7 +138,12 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
             var routePattern = context.Request.Path;
             if (routePattern == null)
             {
-                return string.Empty;
+                return "/";
+            }
+
+            if (RouteHelper.PathIsSingleSegment(context.Request.Path))
+            {
+                return "/" + context.Request.Path.TrimStart('/');
             }
 
             // Use the .NET framework route collection to match against the request path
@@ -176,14 +181,14 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                 }
             }
 
-            // Override with raw path if it's a single route parameter
-            if (RouteParameterHelper.PathIsSingleRouteParameter(routePattern))
+            // Add a leading slash to the route pattern if not present
+            // Ensure route pattern starts with a slash and handle null case
+            if (string.IsNullOrEmpty(routePattern))
             {
-                routePattern = context.Request.Path;
+                return "/";
             }
 
-            // Add a leading slash to the route pattern if not present
-            return routePattern != null ? "/" + routePattern.TrimStart('/') : string.Empty;
+            return "/" + routePattern.TrimStart('/');
         }
 
         private string GetRoutePattern(RouteBase route)

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -1,13 +1,13 @@
 using System;
-using Aikido.Zen.Core;
-using System.Web;
 using System.Linq;
-using Aikido.Zen.Core.Helpers;
-using System.Threading.Tasks;
-using Context = Aikido.Zen.Core.Context;
-using Aikido.Zen.Core.Models;
-using System.Web.Routing;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Web;
+using System.Web.Routing;
+using Aikido.Zen.Core;
+using Aikido.Zen.Core.Helpers;
+using Aikido.Zen.Core.Models;
+using Context = Aikido.Zen.Core.Context;
 
 [assembly: InternalsVisibleTo("Aikido.Zen.Tests.DotNetFramework")]
 namespace Aikido.Zen.DotNetFramework.HttpModules
@@ -127,6 +127,12 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                 : httpContext.Request.ServerVariables["REMOTE_ADDR"];
         }
 
+        /// <summary>
+        /// Gets a parameterized route from the HTTP context, matching against the route collection
+        /// and applying route parameter detection when needed.
+        /// </summary>
+        /// <param name="context">The HTTP context containing the request information</param>
+        /// <returns>A parameterized route string with a leading slash</returns>
         internal string GetParametrizedRoute(HttpContext context)
         {
             var routePattern = context.Request.Path;
@@ -162,15 +168,22 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                 var parameterizedRoute = RouteParameterHelper.BuildRouteFromUrl(context.Request.Url.ToString());
                 if (!string.IsNullOrEmpty(parameterizedRoute))
                 {
-                    return "/" + parameterizedRoute.TrimStart('/');
+                    routePattern = parameterizedRoute;
                 }
                 else
                 {
-                    return "/" + context.Request.Path.TrimStart('/');
+                    routePattern = context.Request.Path;
                 }
             }
 
-            return "/" + routePattern.TrimStart('/');
+            // Override with raw path if it's a single route parameter
+            if (RouteParameterHelper.PathIsSingleRouteParameter(routePattern))
+            {
+                routePattern = context.Request.Path;
+            }
+
+            // Add a leading slash to the route pattern if not present
+            return routePattern != null ? "/" + routePattern.TrimStart('/') : string.Empty;
         }
 
         private string GetRoutePattern(RouteBase route)

--- a/Aikido.Zen.Test/Helpers/RouteParameterHelperTests.cs
+++ b/Aikido.Zen.Test/Helpers/RouteParameterHelperTests.cs
@@ -1,9 +1,7 @@
-using System;
+
 using System.Security.Cryptography;
 using System.Text;
-using NUnit.Framework;
 using Aikido.Zen.Core.Helpers;
-using System.Linq;
 
 namespace Aikido.Zen.Test.Helpers
 {
@@ -264,6 +262,36 @@ namespace Aikido.Zen.Test.Helpers
         public void LooksLikeASecret_KnownSecrets_ReturnsTrue(string input)
         {
             Assert.That(RouteParameterHelper.LooksLikeASecret(input), Is.True);
+        }
+
+        [TestCase("/:uuid", true)]
+        [TestCase("/:ulid", true)]
+        [TestCase("/:objectId", true)]
+        [TestCase("/:email", true)]
+        [TestCase("/:hash", true)]
+        [TestCase("/:secret", true)]
+        [TestCase("/:number", true)]
+        [TestCase("/:date", true)]
+        [TestCase("/{param}", true)]
+        [TestCase("/{productId}", true)]
+        [TestCase("/api/:uuid", true)]
+        [TestCase("/api/v1/:uuid", true)]
+        [TestCase("/api/v2/:number", true)]
+        [TestCase("/api/v3/{id}", true)]
+        [TestCase("/users/:number", false)]
+        [TestCase("/api/v3/users/{id}/roles", false)]
+        [TestCase("/posts/:uuid/comments", false)] 
+        [TestCase("/api/v1/users/:number", false)] 
+        [TestCase("/api/v1/items/:id/details", false)]
+        [TestCase("/users/123", false)]
+        [TestCase("/products/some-product", false)]
+        [TestCase("/files/document.pdf", false)]
+        [TestCase("/", false)] // Root path
+        [TestCase("", false)] // Empty path
+        [TestCase("/path/with/multiple/segments", false)] // Multiple non-parameter segments
+        public void PathIsSingleRouteParameter_VariousPaths_ReturnsExpectedResult(string path, bool expectedResult)
+        {
+            Assert.That(RouteParameterHelper.PathIsSingleRouteParameter(path), Is.EqualTo(expectedResult));
         }
     }
 }

--- a/Aikido.Zen.Test/Helpers/RouteParameterHelperTests.cs
+++ b/Aikido.Zen.Test/Helpers/RouteParameterHelperTests.cs
@@ -263,35 +263,5 @@ namespace Aikido.Zen.Test.Helpers
         {
             Assert.That(RouteParameterHelper.LooksLikeASecret(input), Is.True);
         }
-
-        [TestCase("/:uuid", true)]
-        [TestCase("/:ulid", true)]
-        [TestCase("/:objectId", true)]
-        [TestCase("/:email", true)]
-        [TestCase("/:hash", true)]
-        [TestCase("/:secret", true)]
-        [TestCase("/:number", true)]
-        [TestCase("/:date", true)]
-        [TestCase("/{param}", true)]
-        [TestCase("/{productId}", true)]
-        [TestCase("/api/:uuid", true)]
-        [TestCase("/api/v1/:uuid", true)]
-        [TestCase("/api/v2/:number", true)]
-        [TestCase("/api/v3/{id}", true)]
-        [TestCase("/users/:number", false)]
-        [TestCase("/api/v3/users/{id}/roles", false)]
-        [TestCase("/posts/:uuid/comments", false)] 
-        [TestCase("/api/v1/users/:number", false)] 
-        [TestCase("/api/v1/items/:id/details", false)]
-        [TestCase("/users/123", false)]
-        [TestCase("/products/some-product", false)]
-        [TestCase("/files/document.pdf", false)]
-        [TestCase("/", false)] // Root path
-        [TestCase("", false)] // Empty path
-        [TestCase("/path/with/multiple/segments", false)] // Multiple non-parameter segments
-        public void PathIsSingleRouteParameter_VariousPaths_ReturnsExpectedResult(string path, bool expectedResult)
-        {
-            Assert.That(RouteParameterHelper.PathIsSingleRouteParameter(path), Is.EqualTo(expectedResult));
-        }
     }
 }

--- a/Aikido.Zen.Test/RatelimitingHelperTests.cs
+++ b/Aikido.Zen.Test/RatelimitingHelperTests.cs
@@ -1,6 +1,6 @@
+using Aikido.Zen.Core;
 using Aikido.Zen.Core.Helpers;
 using Aikido.Zen.Core.Models;
-using Aikido.Zen.Core;
 
 namespace Aikido.Zen.Test.Helpers
 {
@@ -337,7 +337,7 @@ namespace Aikido.Zen.Test.Helpers
         public void IsRequestAllowed_ShouldRespectExactMatch()
         {
             // Arrange
-            var context = new Context { Method = "GET", Route = "api/users" };
+            var context = new Context { Method = "GET", Route = "api/{entity}", Url = "api/users" };
             context.User = new User("user123", "Test User");
 
             var endpoints = new List<EndpointConfig>

--- a/Aikido.Zen.Test/RouteHelperTests.cs
+++ b/Aikido.Zen.Test/RouteHelperTests.cs
@@ -802,5 +802,17 @@ namespace Aikido.Zen.Test.Helpers
                 Assert.That(matchedEndpoint, Is.Null);
             });
         }
+
+        [TestCase("/", true)]
+        [TestCase("", true)]
+        [TestCase("/test+something", true)]
+        [TestCase("/:email", true)]
+        [TestCase("/api/v1/test", false)]
+        [TestCase("/api/v3/users/{id}/roles", false)]
+        [TestCase("/path/with/multiple/segments", false)] // Multiple non-parameter segments
+        public void PathIsSingleRouteParameter_VariousPaths_ReturnsExpectedResult(string path, bool expectedResult)
+        {
+            Assert.That(RouteHelper.PathIsSingleSegment(path), Is.EqualTo(expectedResult));
+        }
     }
 }

--- a/Aikido.Zen.Tests.DotNetCore/ContextMiddlewareTests.cs
+++ b/Aikido.Zen.Tests.DotNetCore/ContextMiddlewareTests.cs
@@ -94,7 +94,7 @@ namespace Aikido.Zen.Tests.DotNetCore
         }
 
         [Test]
-        public void GetParametrizedRoute_ReturnsEmptyString_ForNullPath()
+        public void GetParametrizedRoute_ReturnsForwardSlash_ForNullPath()
         {
             // Arrange
             _mockHttpContext.Setup(c => c.Request.Path).Returns((string)null);
@@ -103,7 +103,7 @@ namespace Aikido.Zen.Tests.DotNetCore
             var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
 
             // Assert
-            Assert.That(string.Empty, Is.EqualTo(route));
+            Assert.That("/", Is.EqualTo(route));
         }
 
         [Test]
@@ -191,7 +191,7 @@ namespace Aikido.Zen.Tests.DotNetCore
         }
 
         [Test]
-        public void GetParametrizedRoute_ReturnsOriginalUrl_WhenPathIsSingleParameter()
+        public void GetParametrizedRoute_ReturnsOriginalUrl_WhenPathIsSingleSegment()
         {
             // Arrange
             // Clear specific endpoints, use only default fallback logic
@@ -204,24 +204,24 @@ namespace Aikido.Zen.Tests.DotNetCore
             // Test case where the path segment *is* a parameter type recognized by BuildRouteFromUrl (like UUID)
             _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/109156be-c4fb-41ea-b1b4-efe1671c5836"));
             var routeUuid = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
-            Assert.That(routeUuid, Is.EqualTo("/109156be-c4fb-41ea-b1b4-efe1671c5836")); // PathIsSingleRouteParameter would return true for /:uuid
+            Assert.That(routeUuid, Is.EqualTo("/109156be-c4fb-41ea-b1b4-efe1671c5836")); // PathIsSingleSegment would return true for /:uuid
 
             // Test case where the path segment is *not* a parameter type recognized by BuildRouteFromUrl
             // but might be considered a slug
             _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/simple-slug"));
             var routeSlug = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
-            Assert.That(routeSlug, Is.EqualTo("/simple-slug")); // PathIsSingleRouteParameter would return false for /simple-slug
+            Assert.That(routeSlug, Is.EqualTo("/simple-slug")); // PathIsSingleSegment would return false for /simple-slug
 
             // Test case where PathIsSingleRouteParameter would be false (multiple segments)
             _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/users/123/profile"));
             var routeMultiSegment = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
-            Assert.That(routeMultiSegment, Is.EqualTo("/users/:number/profile")); // PathIsSingleRouteParameter would return false for /users/:number/profile
+            Assert.That(routeMultiSegment, Is.EqualTo("/users/:number/profile")); // PathIsSingleSegment would return false for /users/:number/profile
 
-            // Test case for API prefix which should be ignored by PathIsSingleRouteParameter
+            // Test case for API prefix which should be ignored by PathIsSingleSegment
             _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/v1/109156be-c4fb-41ea-b1b4-efe1671c5836"));
             var routeApiUuid = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
             // BuildRouteFromUrl handles the full path including /api/v1/
-            Assert.That(routeApiUuid, Is.EqualTo("/api/v1/109156be-c4fb-41ea-b1b4-efe1671c5836")); // PathIsSingleRouteParameter would return true for /:uuid (after stripping prefix)
+            Assert.That(routeApiUuid, Is.EqualTo("/api/v1/:uuid")); // PathIsSingleSegment would return true for /:uuid (after stripping prefix)
 
             // Restore endpoints for other tests if needed (though Setup runs before each test)
             _mockEndpointDataSource.Setup(m => m.Endpoints).Returns(new List<Endpoint>

--- a/Aikido.Zen.Tests.DotNetCore/ContextMiddlewareTests.cs
+++ b/Aikido.Zen.Tests.DotNetCore/ContextMiddlewareTests.cs
@@ -36,7 +36,8 @@ namespace Aikido.Zen.Tests.DotNetCore
                 CreateEndpoint("api/items/special/{id}", "SpecialParameterizedEndpoint"),
                 CreateEndpoint("api/items/special", "SpecialEndpoint"),
                 CreateEndpoint("api/{version}/items/{id}", "VersionedParameterizedEndpoint"),
-                CreateEndpoint("api/v1/items/{id}", "V1ParameterizedEndpoint")
+                CreateEndpoint("api/v1/items/{id}", "V1ParameterizedEndpoint"),
+                CreateEndpoint("{slug}", "SlugEndpoint")
             });
             _mockHttpContext = new Mock<HttpContext>();
             _contextMiddleware = new ContextMiddleware([_mockEndpointDataSource.Object]);

--- a/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
+++ b/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
@@ -151,7 +151,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
         }
 
         [Test]
-        public void GetParametrizedRoute_ReturnsOriginalUrl_WhenPathIsSingleParameter()
+        public void GetParametrizedRoute_ReturnsOriginalUrl_WhenPathIsSingleSegment()
         {
             // Arrange
             // No routes defined, mimics scenario where framework doesn't find a match
@@ -170,27 +170,19 @@ namespace Aikido.Zen.Tests.DotNetFramework
 
 
             // Test case where the path segment *is* a parameter type recognized by BuildRouteFromUrl (like UUID)
-            Assert.That(route, Is.EqualTo("/109156be-c4fb-41ea-b1b4-efe1671c5836")); // PathIsSingleRouteParameter would return true for /:uuid
+            Assert.That(route, Is.EqualTo("/109156be-c4fb-41ea-b1b4-efe1671c5836")); // PathIsSingleSegment would return true for /:uuid
             _mockHttpContext = new HttpContext(
                new HttpRequest(string.Empty, "http://test.local/simple-slug", string.Empty),
                new HttpResponse(null));
             route = _contextModule.GetParametrizedRoute(_mockHttpContext);
-            Assert.That(route, Is.EqualTo("/simple-slug")); // PathIsSingleRouteParameter would return false for /simple-slug
+            Assert.That(route, Is.EqualTo("/simple-slug")); // PathIsSingleSegment would return false for /simple-slug
 
-            // Test case for API prefix which should be ignored by PathIsSingleRouteParameter
-            _mockHttpContext = new HttpContext(
-                new HttpRequest(string.Empty, "http://test.local/api/v1/109156be-c4fb-41ea-b1b4-efe1671c5836", string.Empty),
-                new HttpResponse(null));
-            route = _contextModule.GetParametrizedRoute(_mockHttpContext);
-            // BuildRouteFromUrl handles the full path including /api/v1/
-            Assert.That(route, Is.EqualTo("/api/v1/109156be-c4fb-41ea-b1b4-efe1671c5836")); // PathIsSingleRouteParameter would return true for /:uuid (after stripping prefix)
-
-            // Test case where PathIsSingleRouteParameter would be false (multiple segments)
+            // Test case where PathIsSingleSegment would be false (multiple segments)
             _mockHttpContext = new HttpContext(
                 new HttpRequest(string.Empty, "http://test.local/users/123/profile", string.Empty),
                 new HttpResponse(null));
             route = _contextModule.GetParametrizedRoute(_mockHttpContext);
-            Assert.That(route, Is.EqualTo("/users/:number/profile")); // PathIsSingleRouteParameter would return false for /users/:number/profile
+            Assert.That(route, Is.EqualTo("/users/:number/profile")); // PathIsSingleSegment would return false for /users/:number/profile
         }
     }
 }

--- a/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
+++ b/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
@@ -154,7 +154,10 @@ namespace Aikido.Zen.Tests.DotNetFramework
         public void GetParametrizedRoute_ReturnsOriginalUrl_WhenPathIsSingleSegment()
         {
             // Arrange
-            // No routes defined, mimics scenario where framework doesn't find a match
+            // Add a generic slug route to simulate a catch-all scenario
+            RouteTable.Routes.Add(new System.Web.Routing.Route("{slug}", new StopRoutingHandler()));
+
+            // Test case where the path segment *is* a parameter type recognized by BuildRouteFromUrl (like UUID)
             _mockHttpContext = new HttpContext(
                 new HttpRequest(string.Empty, "http://test.local/this-is-a-potential-slug", string.Empty),
                 new HttpResponse(null));
@@ -168,8 +171,6 @@ namespace Aikido.Zen.Tests.DotNetFramework
                 new HttpResponse(null));
             route = _contextModule.GetParametrizedRoute(_mockHttpContext);
 
-
-            // Test case where the path segment *is* a parameter type recognized by BuildRouteFromUrl (like UUID)
             Assert.That(route, Is.EqualTo("/109156be-c4fb-41ea-b1b4-efe1671c5836")); // PathIsSingleSegment would return true for /:uuid
             _mockHttpContext = new HttpContext(
                new HttpRequest(string.Empty, "http://test.local/simple-slug", string.Empty),

--- a/SampleApp.Common/BaseStartup.cs
+++ b/SampleApp.Common/BaseStartup.cs
@@ -1,16 +1,16 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using System.Text.Json;
-using Aikido.Zen.DotNetCore;
-using SampleApp.Common.Controllers;
-using Microsoft.AspNetCore.Http;
 using System.Net;
 using System.Security.Claims;
-using Aikido.Zen.Core.Exceptions;
+using System.Text.Json;
 using Aikido.Zen.Core;
+using Aikido.Zen.Core.Exceptions;
+using Aikido.Zen.DotNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using SampleApp.Common.Controllers;
 
 namespace SampleApp.Common
 {
@@ -191,6 +191,27 @@ namespace SampleApp.Common
                     };
 
                     return Results.Ok(stats); // Return HTTP 200 OK with the stats object
+                });
+
+                // generic api endpoint /api/v1/{slug} using mapget
+                endpoints.MapGet("/api/v1/{slug}", (string slug) =>
+                {
+                    return Results.Ok(new { slug = slug });
+                });
+
+                // generic api endpoint /api/v1/{slug}/test using mapget
+                endpoints.MapGet("/api/v1/{slug}/test", (string slug) =>
+                {
+                    return Results.Ok(new { slug = slug });
+                });
+
+                endpoints.MapGet("/api/prioritytest/{id}", (int id) =>
+                {
+                    return Results.Ok(new { id = id });
+                });
+                endpoints.MapPost("/api/prioritytest/{id}", (int id) =>
+                {
+                    return Results.Ok(new { id = id });
                 });
             });
         }


### PR DESCRIPTION
In order to better handle ratelimiting and blocking per endpoint in .Net the following changes where made:

- better priority handling for multiple endpoint configurations: (e.g. https://www.domain/com/users/123)
  1. Exact method + exact url path e.g. GET /users/123
  2. Exact method + exact route e.g. GET /users/:int
  3. wildcard method + exact url path e.g. * /users/123
  4. wildcard method + exact route e.g. * /users/:int
  5. Exact method + wildcard route e.g. GET /users/*
  6. Exact method + wildcard route e.g. * /users/*
  
- we don't parametrize routes that are too generic to avoid aggregating all routes into one discovered endpoint.
   e.g. /api/{Slug} or /{Slug} or /api/v2/{Slug}
   This is useful for applications that have one catch all Route in their Route table.