### PR TITLE
better blocking copy

### DIFF
--- a/Aikido.Zen.Core/Models/Ip/Blocklist.cs
+++ b/Aikido.Zen.Core/Models/Ip/Blocklist.cs
@@ -279,7 +279,7 @@ namespace Aikido.Zen.Core.Models.Ip
             reason = null;
             if (IsPrivateOrLocalIp(context.RemoteAddress))
             {
-                reason = "Ip is private or local";
+                reason = "IP is private or local";
                 return false;
             }
             if (IsIPBypassed(context.RemoteAddress))
@@ -289,17 +289,17 @@ namespace Aikido.Zen.Core.Models.Ip
             }
             if (IsIPBlocked(context.RemoteAddress))
             {
-                reason = "IP is not allowed";
+                reason = "IP is blocked";
                 return true;
             }
             if (!IsIpAllowedForEndpoint(context))
             {
-                reason = "Ip is not allowed";
+                reason = "IP is not allowed for this endpoint";
                 return true;
             }
             if (!IsIPAllowed(context.RemoteAddress))
             {
-                reason = "Ip is not allowed";
+                reason = "IP is not allowed";
                 return true;
             }
             return false;

--- a/Aikido.Zen.Test.End2End/AikidoBlockingTests.cs
+++ b/Aikido.Zen.Test.End2End/AikidoBlockingTests.cs
@@ -100,7 +100,7 @@ namespace Aikido.Zen.Test.End2End
             // Assert
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
             var responseBody = await response.Content.ReadAsStringAsync();
-            Assert.That(responseBody, Does.Contain("Your request is blocked: IP is not allowed"));
+            Assert.That(responseBody, Does.Contain("Your request is blocked: IP is blocked"));
         }
 
         [Test]
@@ -248,10 +248,10 @@ namespace Aikido.Zen.Test.End2End
             // Assert
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
             var responseBody = await response.Content.ReadAsStringAsync();
-            Assert.That(responseBody, Does.Contain("Your request is blocked: Ip is not allowed"));
+            Assert.That(responseBody, Does.Contain("Your request is blocked: IP is not allowed for this endpoint"));
             Assert.That(response2.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
             var responseBody2 = await response2.Content.ReadAsStringAsync();
-            Assert.That(responseBody2, Does.Contain("Your request is blocked: Ip is not allowed"));
+            Assert.That(responseBody2, Does.Contain("Your request is blocked: IP is not allowed for this endpoint"));
         }
 
         [Test]
@@ -338,7 +338,7 @@ namespace Aikido.Zen.Test.End2End
             // Assert
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
             var responseBody = await response.Content.ReadAsStringAsync();
-            Assert.That(responseBody, Does.Contain("Your request is blocked: Ip is not allowed"));
+            Assert.That(responseBody, Does.Contain("Your request is blocked: IP is not allowed"));
         }
 
         /// <summary>
@@ -449,7 +449,7 @@ namespace Aikido.Zen.Test.End2End
             // Assert: Request should be blocked because the specific rule (Priority 2) takes precedence and does not allow this IP
             Assert.That(responseBlocked.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
             var responseBodyBlocked = await responseBlocked.Content.ReadAsStringAsync();
-            Assert.That(responseBodyBlocked, Does.Contain("Your request is blocked: Ip is not allowed"));
+            Assert.That(responseBodyBlocked, Does.Contain("Your request is blocked: IP is not allowed for this endpoint"));
         }
 
         /// <summary>
@@ -559,7 +559,7 @@ namespace Aikido.Zen.Test.End2End
             // Assert: Request should be blocked
             Assert.That(responseBlocked.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
             var responseBodyBlocked = await responseBlocked.Content.ReadAsStringAsync();
-            Assert.That(responseBodyBlocked, Does.Contain("Your request is blocked: Ip is not allowed"));
+            Assert.That(responseBodyBlocked, Does.Contain("Your request is blocked: IP is not allowed for this endpoint"));
         }
     }
 }


### PR DESCRIPTION
consistently write 'IP' instead of 'Ip' + provide more specific reasons about why a request is blocked or not