### PR TITLE
JsonSerializer: camelcasing, include public fields and ignore proeprty casing on deserialization

### DIFF
--- a/Aikido.Zen.Core/Api/Api.cs
+++ b/Aikido.Zen.Core/Api/Api.cs
@@ -1,13 +1,21 @@
+using System.Text.Json;
+
 namespace Aikido.Zen.Core.Api
 {
-	public class ZenApi : IZenApi
-	{
-		public ZenApi(IReportingAPIClient reporting, IRuntimeAPIClient runtime)
-		{
-			Reporting = reporting;
+    public class ZenApi : IZenApi
+    {
+        public static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            IncludeFields = true,
+            PropertyNameCaseInsensitive = true,
+        };
+        public ZenApi(IReportingAPIClient reporting, IRuntimeAPIClient runtime)
+        {
+            Reporting = reporting;
             Runtime = runtime;
-		}
-		public IReportingAPIClient Reporting { get; private set; }
+        }
+        public IReportingAPIClient Reporting { get; private set; }
         public IRuntimeAPIClient Runtime { get; private set; }
     }
 }

--- a/Aikido.Zen.Core/Api/Reporting.cs
+++ b/Aikido.Zen.Core/Api/Reporting.cs
@@ -1,4 +1,3 @@
-using Aikido.Zen.Core.Helpers;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -7,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Aikido.Zen.Core.Helpers;
 
 namespace Aikido.Zen.Core.Api
 {
@@ -44,7 +44,7 @@ namespace Aikido.Zen.Core.Api
                 try
                 {
                     // make sure the json string does not use unicode the escape characters
-                    var eventAsJson = JsonSerializer.Serialize(@event, options: new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+                    var eventAsJson = JsonSerializer.Serialize(@event, ZenApi.JsonSerializerOptions);
                     var requestContent = new StringContent(eventAsJson, Encoding.UTF8, "application/json");
                     var request = APIHelper.CreateRequest(token, new Uri(EnvironmentHelper.AikidoUrl), "api/runtime/events", HttpMethod.Post, requestContent);
 

--- a/Aikido.Zen.Core/Helpers/APIHelper.cs
+++ b/Aikido.Zen.Core/Helpers/APIHelper.cs
@@ -1,7 +1,7 @@
-using Aikido.Zen.Core.Api;
 using System;
 using System.Net.Http;
 using System.Text.Json;
+using Aikido.Zen.Core.Api;
 
 namespace Aikido.Zen.Core.Helpers
 {
@@ -38,7 +38,7 @@ namespace Aikido.Zen.Core.Helpers
                 try
                 {
                     var data = response.Content.ReadAsStringAsync().Result;
-                    var result = JsonSerializer.Deserialize<T>(data, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+                    var result = JsonSerializer.Deserialize<T>(data, ZenApi.JsonSerializerOptions);
                     result.Success = true;
                     return result;
                 }


### PR DESCRIPTION
JsonSerializer: camelcasing, include public fields and ignore proeprty casing on deserialization