### PR TITLE
embedded dependencies

### DIFF
--- a/Aikido.Zen.DotNetCore/Aikido.Zen.DotNetCore.csproj
+++ b/Aikido.Zen.DotNetCore/Aikido.Zen.DotNetCore.csproj
@@ -31,6 +31,8 @@
     <PackageReference Include="System.Text.Json" Version="8.0.5" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="System.Text.Json" Version="9.0.1" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Fody" Version="6.9.0" PrivateAssets="All" />
+    <PackageReference Include="Costura.Fody" Version="6.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Aikido.Zen.DotNetCore/Aikido.Zen.DotNetCore.nuspec
+++ b/Aikido.Zen.DotNetCore/Aikido.Zen.DotNetCore.nuspec
@@ -21,56 +21,9 @@
         <frameworkReference name="Microsoft.AspNetCore.App" />
       </group>
     </frameworkReferences>
-    <!--<dependencies>
-      <group targetFramework="net9.0">
+    <<dependencies>
         <dependency id="Lib.Harmony" version="[2.3.5,)" />
-        <dependency id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.2.0" />
-        <dependency id="Microsoft.AspNetCore.Http" version="2.2.2" />
-        <dependency id="Microsoft.AspNetCore.Routing" version="2.2.2" />
-        <dependency id="Microsoft.AspNetCore.Routing.Abstractions" version="2.2.0" />
-        <dependency id="Microsoft.Extensions.DependencyInjection" version="[9.0,)" />
-        <dependency id="Microsoft.Extensions.Options" version="[9.0,)" />
-        <dependency id="System.Text.Json" version="[9.0.1,)" />
-        <dependency id="Microsoft.Extensions.Logging" version="[9.0,)" />
-        <dependency id="Microsoft.Extensions.Logging.Console" version="[9.0,)" />
-      </group>
-      <group targetFramework="net8.0">
-        <dependency id="Lib.Harmony" version="[2.3.5,)" />
-        <dependency id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.2.0" />
-        <dependency id="Microsoft.AspNetCore.Http" version="2.2.2" />
-        <dependency id="Microsoft.AspNetCore.Routing" version="2.2.2" />
-        <dependency id="Microsoft.AspNetCore.Routing.Abstractions" version="2.2.0" />
-        <dependency id="Microsoft.Extensions.DependencyInjection" version="[8.0,)" />
-        <dependency id="Microsoft.Extensions.Options" version="[8.0,)" />
-        <dependency id="System.Text.Json" version="[8.0.5,)" />
-        <dependency id="Microsoft.Extensions.Logging" version="[8.0,)" />
-          <dependency id="Microsoft.Extensions.Logging.Console" version="[8.0,)" />
-      </group>
-      <group targetFramework="net7.0">
-        <dependency id="Lib.Harmony" version="[2.3.5,)" />
-        <dependency id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.2.0" />
-        <dependency id="Microsoft.AspNetCore.Http" version="2.2.2" />
-        <dependency id="Microsoft.AspNetCore.Routing" version="2.2.2" />
-        <dependency id="Microsoft.AspNetCore.Routing.Abstractions" version="2.2.0" />
-        <dependency id="Microsoft.Extensions.DependencyInjection" version="[7.0,)" />
-        <dependency id="Microsoft.Extensions.Options" version="[7.0,)" />
-        <dependency id="System.Text.Json" version="[8.0.5,)" />
-        <dependency id="Microsoft.Extensions.Logging" version="[7.0,)" />
-          <dependency id="Microsoft.Extensions.Logging.Console" version="[7.0,)" />
-      </group>
-      <group targetFramework="net6.0">
-        <dependency id="Lib.Harmony" version="[2.3.5,)" />
-        <dependency id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.2.0" />
-        <dependency id="Microsoft.AspNetCore.Http" version="2.2.2" />
-        <dependency id="Microsoft.AspNetCore.Routing" version="2.2.2" />
-        <dependency id="Microsoft.AspNetCore.Routing.Abstractions" version="2.2.0" />
-        <dependency id="Microsoft.Extensions.DependencyInjection" version="[6.0,)" />
-        <dependency id="Microsoft.Extensions.Options" version="[6.0,)" />
-        <dependency id="System.Text.Json" version="[6.0,)" />
-        <dependency id="Microsoft.Extensions.Logging" version="[6.0,)" />
-        <dependency id="Microsoft.Extensions.Logging.Console" version="[6.0,)" />
-      </group>
-    </dependencies>-->
+    </dependencies>
   </metadata>
   <files>
     <file src="Aikido.Zen.DotNetCore.targets" target="Build\" />

--- a/Aikido.Zen.DotNetCore/Aikido.Zen.DotNetCore.nuspec
+++ b/Aikido.Zen.DotNetCore/Aikido.Zen.DotNetCore.nuspec
@@ -21,7 +21,7 @@
         <frameworkReference name="Microsoft.AspNetCore.App" />
       </group>
     </frameworkReferences>
-    <<dependencies>
+    <dependencies>
         <dependency id="Lib.Harmony" version="[2.3.5,)" />
     </dependencies>
   </metadata>

--- a/Aikido.Zen.DotNetCore/Aikido.Zen.DotNetCore.nuspec
+++ b/Aikido.Zen.DotNetCore/Aikido.Zen.DotNetCore.nuspec
@@ -21,7 +21,7 @@
         <frameworkReference name="Microsoft.AspNetCore.App" />
       </group>
     </frameworkReferences>
-    <dependencies>
+    <!--<dependencies>
       <group targetFramework="net9.0">
         <dependency id="Lib.Harmony" version="[2.3.5,)" />
         <dependency id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.2.0" />
@@ -70,10 +70,11 @@
         <dependency id="Microsoft.Extensions.Logging" version="[6.0,)" />
         <dependency id="Microsoft.Extensions.Logging.Console" version="[6.0,)" />
       </group>
-    </dependencies>
+    </dependencies>-->
   </metadata>
   <files>
     <file src="Aikido.Zen.DotNetCore.targets" target="Build\" />
+    <file src="FodyWeavers.xml" target="Build\" />
     <file src="bin\Release\net9.0\Aikido.Zen.Core.dll" target="lib\net9.0" />
     <file src="bin\Release\net8.0\Aikido.Zen.Core.dll" target="lib\net8.0" />
     <file src="bin\Release\net7.0\Aikido.Zen.Core.dll" target="lib\net7.0" />

--- a/Aikido.Zen.DotNetCore/FodyWeavers.xml
+++ b/Aikido.Zen.DotNetCore/FodyWeavers.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
   <Costura>
+    <!-- We can't embed the harmony assembly because it's not a managed assembly -->
+    <!-- Unmanaged32Assemblies and Unmanaged64Assemblies are only supported on windows -->
+    <!-- This means Harmony.Lib will be added as a transient nuget package as an external dependency -->
     <ExcludeAssemblies>
       Lib.Harmony
     </ExcludeAssemblies>

--- a/Aikido.Zen.DotNetCore/FodyWeavers.xml
+++ b/Aikido.Zen.DotNetCore/FodyWeavers.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <Costura CreateTemporaryAssemblies='true' DisableCleanup='true'>
+    <Unmanaged32Assemblies>
+      Lib.Harmony
+    </Unmanaged32Assemblies>
+    <Unmanaged64Assemblies>
+      Lib.Harmony
+    </Unmanaged64Assemblies>
+  </Costura>
+</Weavers>

--- a/Aikido.Zen.DotNetCore/FodyWeavers.xml
+++ b/Aikido.Zen.DotNetCore/FodyWeavers.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura CreateTemporaryAssemblies='true' DisableCleanup='true'>
-    <Unmanaged32Assemblies>
+  <Costura>
+    <ExcludeAssemblies>
       Lib.Harmony
-    </Unmanaged32Assemblies>
-    <Unmanaged64Assemblies>
-      Lib.Harmony
-    </Unmanaged64Assemblies>
+    </ExcludeAssemblies>
   </Costura>
 </Weavers>

--- a/Aikido.Zen.DotNetFramework/Aikido.Zen.DotNetFramework.csproj
+++ b/Aikido.Zen.DotNetFramework/Aikido.Zen.DotNetFramework.csproj
@@ -58,11 +58,16 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="ZstdSharp.Port" Version="0.8.0" />
+    <PackageReference Include="Fody" Version="6.9.0" PrivateAssets="All" />
+    <PackageReference Include="Costura.Fody" Version="6.0.0" PrivateAssets="All" />
     <Reference Include="System.Web" />
   </ItemGroup>
 
   <ItemGroup>
     <None Update="app.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="FodyWeavers.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Aikido.Zen.DotNetFramework/Aikido.Zen.DotNetFramework.nuspec
+++ b/Aikido.Zen.DotNetFramework/Aikido.Zen.DotNetFramework.nuspec
@@ -11,12 +11,9 @@
     <license type="expression">MIT</license>
     <copyright>Copyright 2024 Aikido</copyright>
     <tags>firewall .NET</tags>
-    <!--<dependencies>
+    <dependencies>
         <dependency id="Lib.Harmony" version="[2.3.5,)" />
-        <dependency id="Microsoft.AspNetCore.WebUtilities" version="[2.2.0,)" />
-        <dependency id="Microsoft.Extensions.Logging.Abstractions" version="[6.0.0,)" />
-        <dependency id="Microsoft.Extensions.Logging.Console" version="[6.0.0,)" />
-    </dependencies>-->
+    </dependencies>
   </metadata>
   <files>
     <file src="Aikido.Zen.DotNetFramework.targets" target="Build\" />

--- a/Aikido.Zen.DotNetFramework/Aikido.Zen.DotNetFramework.nuspec
+++ b/Aikido.Zen.DotNetFramework/Aikido.Zen.DotNetFramework.nuspec
@@ -11,22 +11,18 @@
     <license type="expression">MIT</license>
     <copyright>Copyright 2024 Aikido</copyright>
     <tags>firewall .NET</tags>
-    <dependencies>
+    <!--<dependencies>
         <dependency id="Lib.Harmony" version="[2.3.5,)" />
-        <dependency id="Microsoft.AspNetCore.Http.Abstractions" version="[2.2.0,)" />
         <dependency id="Microsoft.AspNetCore.WebUtilities" version="[2.2.0,)" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="[6.0.0,)" />
         <dependency id="Microsoft.Extensions.Logging.Console" version="[6.0.0,)" />
-        <dependency id="System.Text.Json" version="[6.0.0,)" />
-    </dependencies>
+    </dependencies>-->
   </metadata>
   <files>
     <file src="Aikido.Zen.DotNetFramework.targets" target="Build\" />
+    <file src="FodyWeavers.xml" target="Build\" />
     <file src="bin\Release\net48\libraries\libzen_internals_x86_64-pc-windows-gnu.dll" target="Build\libraries\" />
     <file src="bin\Release\net48\libraries\libzen_internals_x86_64-pc-windows-gnu.dll.sha256sum" target="Build\libraries\" />
-    <file src="bin\Release\net461\Aikido.Zen.Core.dll" target="lib\net461" />
-    <file src="bin\Release\net47\Aikido.Zen.Core.dll" target="lib\net47" />
-    <file src="bin\Release\net48\Aikido.Zen.Core.dll" target="lib\net48" />
     <file src="bin\Release\net461\Aikido.Zen.DotNetFramework.dll" target="lib\net461" />
     <file src="bin\Release\net47\Aikido.Zen.DotNetFramework.dll" target="lib\net47" />
     <file src="bin\Release\net48\Aikido.Zen.DotNetFramework.dll" target="lib\net48" />

--- a/Aikido.Zen.DotNetFramework/FodyWeavers.xml
+++ b/Aikido.Zen.DotNetFramework/FodyWeavers.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <Costura CreateTemporaryAssemblies='true' DisableCleanup='true'>
+    <Unmanaged32Assemblies>
+      Lib.Harmony
+    </Unmanaged32Assemblies>
+    <Unmanaged64Assemblies>
+      Lib.Harmony
+    </Unmanaged64Assemblies>
+  </Costura>
+</Weavers>

--- a/sample-apps/DotNetCore.Sample.App/FodyWeavers.xml
+++ b/sample-apps/DotNetCore.Sample.App/FodyWeavers.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <Costura CreateTemporaryAssemblies='true' DisableCleanup='true'>
+    <Unmanaged32Assemblies>
+      Lib.Harmony
+    </Unmanaged32Assemblies>
+    <Unmanaged64Assemblies>
+      Lib.Harmony
+    </Unmanaged64Assemblies>
+  </Costura>
+</Weavers>


### PR DESCRIPTION
embedding most dependencies to avoid dll version hell and making the installation much less painfull.

deps that cannot be embedded:

- Harmony.Lib
- Internal zen library

This is not a big issue since both are very unlikely to be used already by consuming apps.