### PR TITLE
Avoid depending on the c:/windows/temp folder

### DIFF
--- a/Aikido.Zen.DotNetFramework/FodyWeavers.xml
+++ b/Aikido.Zen.DotNetFramework/FodyWeavers.xml
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura CreateTemporaryAssemblies='true' DisableCleanup='true'>
+  <Costura CreateTemporaryAssemblies='false'>
     <IncludeProjectReferences>true</IncludeProjectReferences>
-    <Unmanaged32Assemblies>
-      Lib.Harmony
-    </Unmanaged32Assemblies>
-    <Unmanaged64Assemblies>
-      Lib.Harmony
-    </Unmanaged64Assemblies>
     <ExcludeAssemblies>
       Aikido.Zen.Core
+      Lib.Harmony
     </ExcludeAssemblies>
   </Costura>
 </Weavers>


### PR DESCRIPTION
We do not want our assembly unpacking to use c:/windows/temp because this can cause access right issues when running multiple Zen enabled apps in IIS