### PR TITLE
Add method that allows to get the current status of heartbeats.

### DIFF
--- a/Aikido.Zen.Core/AgentStatus.cs
+++ b/Aikido.Zen.Core/AgentStatus.cs
@@ -1,0 +1,32 @@
+namespace Aikido.Zen.Core
+{
+    public class AgentStatus
+    {
+        public AgentStatus(ReportingStatusResult heartbeatStatus)
+        {
+            HeartbeatStatus = heartbeatStatus;
+        }
+
+        /// <summary>
+        /// Gets the current heartbeat reporting status of the agent.
+        /// This indicates whether the agent is successfully communicating with the Zen API
+        /// through heartbeat events and other monitoring reports.
+        /// </summary>
+        /// <value>
+        /// A <see cref="ReportingStatusResult"/> value indicating the current reporting status:
+        /// - <see cref="ReportingStatusResult.NotReported"/>: No reporting attempts have been made
+        /// - <see cref="ReportingStatusResult.Ok"/>: Agent is successfully reporting
+        /// - <see cref="ReportingStatusResult.Expired"/>: Heartbeat reporting has expired
+        /// - <see cref="ReportingStatusResult.Failure"/>: The most recent reporting attempt failed
+        /// </value>
+        public ReportingStatusResult HeartbeatStatus { get; }
+    }
+
+    public enum ReportingStatusResult
+    {
+        NotReported,
+        Ok,
+        Expired,
+        Failure,
+    }
+}

--- a/Aikido.Zen.Core/Models/Events/Heartbeat.cs
+++ b/Aikido.Zen.Core/Models/Events/Heartbeat.cs
@@ -7,7 +7,9 @@ namespace Aikido.Zen.Core.Models.Events
 {
     public class Heartbeat : IEvent
     {
-        public string Type => "heartbeat";
+        internal const string HeartbeatEventName = "heartbeat";
+
+        public string Type => HeartbeatEventName;
 
         public AgentStats Stats { get; set; } = new AgentStats();
         public IEnumerable<AiInfo> Ai { get; set; }

--- a/Aikido.Zen.Core/Models/Events/Started.cs
+++ b/Aikido.Zen.Core/Models/Events/Started.cs
@@ -5,7 +5,9 @@ namespace Aikido.Zen.Core.Models.Events
 {
     public class Started : IEvent
     {
-        public string Type => "started";
+        internal const string StartedEventName = "started";
+
+        public string Type => StartedEventName;
         public AgentInfo Agent { get; set; }
         public long Time => DateTimeHelper.UTCNowUnixMilliseconds();
 

--- a/Aikido.Zen.Core/ReportingStatus.cs
+++ b/Aikido.Zen.Core/ReportingStatus.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Concurrent;
+using Aikido.Zen.Core.Models.Events;
+
+namespace Aikido.Zen.Core
+{
+    internal class ReportingStatus
+    {
+        private ReportingStatusEntry? _startedReport;
+        private ReportingStatusEntry? _lastHeartBeatReport;
+        private readonly TimeSpan _gracePeriod = TimeSpan.FromSeconds(30);
+
+        public void SignalReporting(string operation, bool success)
+        {
+            if (operation == Started.StartedEventName)
+            {
+                _startedReport = new ReportingStatusEntry(GetCurrentTime(), success);
+            }
+            else if (operation == Heartbeat.HeartbeatEventName)
+            {
+                _lastHeartBeatReport = new ReportingStatusEntry(GetCurrentTime(), success);
+            }
+        }
+
+        public ReportingStatusResult GetReportingStatus()
+        {
+            var lastReport = _lastHeartBeatReport ?? _startedReport;
+            if (lastReport == null)
+            {
+                return ReportingStatusResult.NotReported;
+            }
+
+            if (!lastReport.Value.Success)
+            {
+                return ReportingStatusResult.Failure;
+            }
+
+            var now = GetCurrentTime();
+            // A grace period is added to allow for slight delays in reporting
+            // This helps avoid false expirations due to network latency or short processing delays
+            if (lastReport.Value.LastReported.Add(Heartbeat.Interval).Add(_gracePeriod) < now)
+            {
+                return ReportingStatusResult.Expired;
+            }
+
+            return ReportingStatusResult.Ok;
+        }
+
+        protected virtual DateTime GetCurrentTime()
+        {
+            return DateTime.UtcNow;
+        }
+
+        private struct ReportingStatusEntry
+        {
+            public ReportingStatusEntry(DateTime lastReported, bool success)
+            {
+                LastReported = lastReported;
+                Success = success;
+            }
+
+            public DateTime LastReported { get; }
+            public bool Success { get; }
+        }
+    }
+}

--- a/Aikido.Zen.DotNetCore/Zen.cs
+++ b/Aikido.Zen.DotNetCore/Zen.cs
@@ -40,5 +40,20 @@ namespace Aikido.Zen.DotNetCore
             var contextAccessor = _serviceProvider.GetService(typeof(ContextAccessor)) as ContextAccessor;
             return contextAccessor?.CurrentUser;
         }
+
+        /// <summary>
+        /// Gets the current status of the Aikido Zen agent, including heartbeat reporting status.
+        /// This method provides a snapshot of the agent's communication status with the Zen API.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="AgentStatus"/> object containing the current status information, including:
+        /// - Heartbeat reporting status indicating whether the agent is successfully communicating with the Zen API
+        /// - Success/failure state of recent API communications
+        /// - Whether heartbeat reports have expired or are current
+        /// </returns>
+        public static AgentStatus Status()
+        {
+            return Agent.Instance?.GetCurrentStatus();
+        }
     }
 }

--- a/Aikido.Zen.DotNetFramework/Zen.cs
+++ b/Aikido.Zen.DotNetFramework/Zen.cs
@@ -100,5 +100,20 @@ namespace Aikido.Zen.DotNetFramework
             LogHelper.DebugLog(Agent.Logger, "Initializing the Zen modules manually");
             RegisterModules();
         }
+
+        /// <summary>
+        /// Gets the current status of the Aikido Zen agent, including heartbeat reporting status.
+        /// This method provides a snapshot of the agent's communication status with the Zen API.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="AgentStatus"/> object containing the current status information, including:
+        /// - Heartbeat reporting status indicating whether the agent is successfully communicating with the Zen API
+        /// - Success/failure state of recent API communications
+        /// - Whether heartbeat reports have expired or are current
+        /// </returns>
+        public static AgentStatus Status()
+        {
+            return Agent.Instance?.GetCurrentStatus();
+        }
     }
 }

--- a/Aikido.Zen.Test/ReportingStatusTests.cs
+++ b/Aikido.Zen.Test/ReportingStatusTests.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Threading;
+using Aikido.Zen.Core;
+using Aikido.Zen.Core.Models.Events;
+using NUnit.Framework;
+
+namespace Aikido.Zen.Test
+{
+    [TestFixture]
+    public class ReportingStatusTests
+    {
+        private ReportingStatus _reportingStatus;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _reportingStatus = new ReportingStatus();
+        }
+
+        [Test]
+        public void GetReportingStatus_WhenNoReportsExist_ReturnsNotReported()
+        {
+            // Act
+            var result = _reportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.NotReported));
+        }
+
+        [Test]
+        public void SignalReporting_WithHeartbeatEventSuccess_GetReportingStatusReturnsOk()
+        {
+            // Act
+            _reportingStatus.SignalReporting(Heartbeat.HeartbeatEventName, true);
+            var result = _reportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Ok));
+        }
+
+        [Test]
+        public void SignalReporting_WithStartedEventSuccess_GetReportingStatusReturnsOk()
+        {
+            // Act
+            _reportingStatus.SignalReporting(Started.StartedEventName, true);
+            var result = _reportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Ok));
+        }
+
+        [Test]
+        public void SignalReporting_WithHeartbeatEventFailure_GetReportingStatusReturnsFailure()
+        {
+            // Act
+            _reportingStatus.SignalReporting(Heartbeat.HeartbeatEventName, false);
+            var result = _reportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Failure));
+        }
+
+        [Test]
+        public void SignalReporting_WithStartedEventFailure_GetReportingStatusReturnsFailure()
+        {
+            // Act
+            _reportingStatus.SignalReporting(Started.StartedEventName, false);
+            var result = _reportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Failure));
+        }
+
+        [Test]
+        public void SignalReporting_WithOtherEventSuccess_GetReportingStatusReturnsNotReported()
+        {
+            // Act
+            _reportingStatus.SignalReporting("some_other_event", true);
+            var result = _reportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.NotReported));
+        }
+
+        [Test]
+        public void GetReportingStatus_WhenHeartbeatExpired_ReturnsExpired()
+        {
+            // Arrange
+            var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var testableReportingStatus = new TestableReportingStatus(baseTime);
+            
+            // Signal successful reporting at base time
+            testableReportingStatus.SignalReporting(Heartbeat.HeartbeatEventName, true);
+            
+            // Move time forward beyond heartbeat interval + grace period
+            var expiredTime = baseTime.Add(Heartbeat.Interval).AddSeconds(31); // Grace period is 30 seconds
+            testableReportingStatus.SetCurrentTime(expiredTime);
+
+            // Act
+            var result = testableReportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Expired));
+        }
+
+        [Test]
+        public void GetReportingStatus_WhenStartedExpired_ReturnsExpired()
+        {
+            // Arrange
+            var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var testableReportingStatus = new TestableReportingStatus(baseTime);
+            
+            // Signal successful reporting at base time (only Started event, no Heartbeat)
+            testableReportingStatus.SignalReporting(Started.StartedEventName, true);
+            
+            // Move time forward beyond heartbeat interval + grace period
+            var expiredTime = baseTime.Add(Heartbeat.Interval).AddSeconds(31); // Grace period is 30 seconds
+            testableReportingStatus.SetCurrentTime(expiredTime);
+
+            // Act
+            var result = testableReportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Expired));
+        }
+
+        [Test]
+        public void GetReportingStatus_WhenWithinGracePeriod_ReturnsOk()
+        {
+            // Arrange
+            var baseTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var testableReportingStatus = new TestableReportingStatus(baseTime);
+            
+            // Signal successful reporting at base time
+            testableReportingStatus.SignalReporting(Heartbeat.HeartbeatEventName, true);
+            
+            // Move time forward but still within grace period
+            var withinGracePeriodTime = baseTime.Add(Heartbeat.Interval).AddSeconds(15); // Grace period is 30 seconds
+            testableReportingStatus.SetCurrentTime(withinGracePeriodTime);
+
+            // Act
+            var result = testableReportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Ok));
+        }
+
+        [Test]
+        public void SignalReporting_WithMultipleOperations_PrefersHeartbeatOverStarted()
+        {
+            // Arrange
+            _reportingStatus.SignalReporting(Started.StartedEventName, false);
+            _reportingStatus.SignalReporting(Heartbeat.HeartbeatEventName, true);
+
+            // Act
+            var result = _reportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Ok));
+        }
+
+        [Test]
+        public void SignalReporting_WithStartedFailureThenHeartbeatSuccess_ReturnsOk()
+        {
+            // Arrange
+            _reportingStatus.SignalReporting(Started.StartedEventName, false);
+            _reportingStatus.SignalReporting(Heartbeat.HeartbeatEventName, true);
+
+            // Act
+            var result = _reportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Ok));
+        }
+
+        [Test]
+        public void SignalReporting_WithHeartbeatFailureThenStartedSuccess_ReturnsFailure()
+        {
+            // Arrange - HeartbeatEvent has priority over Started event in GetReportingStatus
+            _reportingStatus.SignalReporting(Heartbeat.HeartbeatEventName, false);
+            _reportingStatus.SignalReporting(Started.StartedEventName, true);
+
+            // Act
+            var result = _reportingStatus.GetReportingStatus();
+
+            // Assert
+            // Heartbeat event takes priority, so even though Started succeeded, Heartbeat failed
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Failure));
+        }
+
+        [Test]
+        public void SignalReporting_OverwritesPreviousStatusForSameOperation()
+        {
+            // Arrange
+            _reportingStatus.SignalReporting(Heartbeat.HeartbeatEventName, false);
+            
+            // Act - overwrite with success
+            _reportingStatus.SignalReporting(Heartbeat.HeartbeatEventName, true);
+            var result = _reportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Ok));
+        }
+
+        [Test]
+        public void SignalReporting_WithEmptyOperation_DoesNotThrow()
+        {
+            // Act & Assert
+            Assert.DoesNotThrow(() => _reportingStatus.SignalReporting("", true));
+            Assert.DoesNotThrow(() => _reportingStatus.SignalReporting(string.Empty, false));
+            Assert.DoesNotThrow(() => _reportingStatus.SignalReporting(null, false));
+        }
+
+        [Test]
+        public void GetReportingStatus_WhenOnlyStartedEventExists_UsesStartedEvent()
+        {
+            // Act
+            _reportingStatus.SignalReporting(Started.StartedEventName, true);
+            var result = _reportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Ok));
+        }
+
+        [Test]
+        public void GetReportingStatus_WhenOnlyStartedEventExistsAndFailed_ReturnsFailure()
+        {
+            // Act
+            _reportingStatus.SignalReporting(Started.StartedEventName, false);
+            var result = _reportingStatus.GetReportingStatus();
+
+            // Assert
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Failure));
+        }
+
+        [Test]
+        public void GetReportingStatus_ConcurrentAccess_ThreadSafe()
+        {
+            // Arrange
+            var results = new ReportingStatusResult[10];
+            var threads = new Thread[10];
+
+            // Act
+            for (int i = 0; i < 10; i++)
+            {
+                int index = i;
+                threads[i] = new Thread(() =>
+                {
+                    _reportingStatus.SignalReporting(Heartbeat.HeartbeatEventName, true);
+                    results[index] = _reportingStatus.GetReportingStatus();
+                });
+                threads[i].Start();
+            }
+
+            // Wait for all threads to complete
+            foreach (var thread in threads)
+            {
+                thread.Join();
+            }
+
+            // Assert
+            foreach (var result in results)
+            {
+                Assert.That(result, Is.EqualTo(ReportingStatusResult.Ok));
+            }
+        }
+
+        [Test]
+        public void GetReportingStatus_PrioritizesHeartbeatOverStartedEvent()
+        {
+            // Arrange - Signal both events with different outcomes
+            _reportingStatus.SignalReporting(Started.StartedEventName, true);
+            _reportingStatus.SignalReporting(Heartbeat.HeartbeatEventName, false);
+
+            // Act
+            var result = _reportingStatus.GetReportingStatus();
+
+            // Assert - Should return failure because Heartbeat has priority and failed
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.Failure));
+        }
+
+        [Test]
+        public void SignalReporting_WithValidOperation_UpdatesReportingStatus()
+        {
+            // Arrange
+            var customOperation = "other_operation";
+
+            // Act
+            _reportingStatus.SignalReporting(customOperation, true);
+
+            // Assert - Custom operations don't affect GetReportingStatus (only Heartbeat and Started do)
+            var result = _reportingStatus.GetReportingStatus();
+            Assert.That(result, Is.EqualTo(ReportingStatusResult.NotReported));
+        }
+
+        // Testable subclass that allows controlling the current time
+        private class TestableReportingStatus : ReportingStatus
+        {
+            private DateTime _currentTime;
+
+            public TestableReportingStatus(DateTime initialTime)
+            {
+                _currentTime = initialTime;
+            }
+
+            public void SetCurrentTime(DateTime time)
+            {
+                _currentTime = time;
+            }
+
+            protected override DateTime GetCurrentTime()
+            {
+                return _currentTime;
+            }
+        }
+    }
+}


### PR DESCRIPTION
`Zen.Status()` allows to get the status of heartbeats being sent to Aikido.

It can be used to monitor the Zen reporting in health checks.

Example for ASP.NET Core:
```cs
var builder = WebApplication.CreateBuilder(args);

// ...

builder.Services.AddZenFirewall();;
builder.Services.AddHealthChecks()
    .AddCheck("Zen firewall reporting status", () => Zen.Status().HeartbeatStatus switch
    {
        ReportingStatusResult.Ok => HealthCheckResult.Healthy("Zen firewall is reporting heartbeats successfully."),
        ReportingStatusResult.NotReported => HealthCheckResult.Degraded("Zen firewall has not reported heartbeats yet."),
        ReportingStatusResult.Expired => HealthCheckResult.Degraded("Zen firewall heartbeat reports have expired."),
        ReportingStatusResult.Failure => HealthCheckResult.Unhealthy("Zen firewall is not reporting heartbeats successfully."),
        _ => HealthCheckResult.Unhealthy("Unknown Zen firewall heartbeat status.")
    });

var app = builder.Build();

// ...

app.UseZenFirewall();
app.MapHealthChecks("/healthz");

app.Run();
```