### PR TITLE
Mark IZenApi, IReportingAPIClient, IRuntimeAPIClient and its implementations as internal.

### DIFF
--- a/Aikido.Zen.Core/Agent.cs
+++ b/Aikido.Zen.Core/Agent.cs
@@ -62,7 +62,7 @@ namespace Aikido.Zen.Core
             }
         }
 
-        public static Agent NewInstance(IZenApi api, int batchTimeoutMs = 5000)
+        internal static Agent NewInstance(IZenApi api, int batchTimeoutMs = 5000)
         {
             _instance = new Agent(api, batchTimeoutMs);
             return _instance;
@@ -73,7 +73,7 @@ namespace Aikido.Zen.Core
         /// </summary>
         /// <param name="api">The Zen API client for reporting events</param>
         /// <param name="batchTimeoutMs">Timeout in milliseconds for batch operations</param>
-        public Agent(IZenApi api, int batchTimeoutMs = 5000)
+        internal Agent(IZenApi api, int batchTimeoutMs = 5000)
         {
             // batchTimeout should be at least 1 second
             if (batchTimeoutMs < 1000)

--- a/Aikido.Zen.Core/Aikido.Zen.Core.csproj
+++ b/Aikido.Zen.Core/Aikido.Zen.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -25,6 +25,9 @@
     <Message Text="Creating NuGet package for Core..." Importance="high" />
     <Exec Command="powershell -ExecutionPolicy Bypass -File ..\\pack.ps1 -buildConfiguration $(Configuration)" />
   </Target>-->
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aikido.Zen.Tests.Mocks"/>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Lib.Harmony" Version="2.3.5" />

--- a/Aikido.Zen.Core/Api/Api.cs
+++ b/Aikido.Zen.Core/Api/Api.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 namespace Aikido.Zen.Core.Api
 {
-    public class ZenApi : IZenApi
+    internal class ZenApi : IZenApi
     {
         public static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
         {

--- a/Aikido.Zen.Core/Api/IReporting.cs
+++ b/Aikido.Zen.Core/Api/IReporting.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Aikido.Zen.Core.Api
 {
-    public interface IReportingAPIClient
+    internal interface IReportingAPIClient
     {
         Task<ReportingAPIResponse> ReportAsync (string token, object @event, int timeoutInMS);
         Task<FirewallListsAPIResponse> GetFirewallLists (string token);

--- a/Aikido.Zen.Core/Api/IRuntime.cs
+++ b/Aikido.Zen.Core/Api/IRuntime.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 
 namespace Aikido.Zen.Core.Api
 {
-    public interface IRuntimeAPIClient
+    internal interface IRuntimeAPIClient
     {
         Task<ReportingAPIResponse> GetConfigLastUpdated(string token);
         Task<ReportingAPIResponse> GetConfig(string token);

--- a/Aikido.Zen.Core/Api/IZenApi.cs
+++ b/Aikido.Zen.Core/Api/IZenApi.cs
@@ -1,6 +1,6 @@
 namespace Aikido.Zen.Core.Api
 {
-	public interface IZenApi
+    internal interface IZenApi
 	{
 		IReportingAPIClient Reporting { get; }
         IRuntimeAPIClient Runtime { get; }

--- a/Aikido.Zen.Core/Api/Reporting.cs
+++ b/Aikido.Zen.Core/Api/Reporting.cs
@@ -10,7 +10,7 @@ using Aikido.Zen.Core.Helpers;
 
 namespace Aikido.Zen.Core.Api
 {
-    public class ReportingAPIClient : IReportingAPIClient
+    internal class ReportingAPIClient : IReportingAPIClient
     {
         private readonly HttpClient _httpClient;
 

--- a/Aikido.Zen.Core/Api/Runtime.cs
+++ b/Aikido.Zen.Core/Api/Runtime.cs
@@ -9,7 +9,7 @@ using System.Net.Http.Headers;
 
 namespace Aikido.Zen.Core.Api
 {
-    public class RuntimeAPIClient : IRuntimeAPIClient
+    internal class RuntimeAPIClient : IRuntimeAPIClient
     {
         private readonly HttpClient _httpClient;
 

--- a/Aikido.Zen.Tests.Mocks/Aikido.Zen.Tests.Mocks.csproj
+++ b/Aikido.Zen.Tests.Mocks/Aikido.Zen.Tests.Mocks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,8 +9,11 @@
     <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
- <ItemGroup>
-   <ProjectReference Include="..\Aikido.Zen.Core\Aikido.Zen.Core.csproj" />
- </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Aikido.Zen.Core\Aikido.Zen.Core.csproj" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aikido.Zen.Tests"/>
+  </ItemGroup>
 </Project>

--- a/Aikido.Zen.Tests.Mocks/ZenApiMock.cs
+++ b/Aikido.Zen.Tests.Mocks/ZenApiMock.cs
@@ -5,7 +5,7 @@ namespace Aikido.Zen.Tests.Mocks
 {
     public static class ZenApiMock
     {
-        public static Mock<IZenApi> CreateMock(IReportingAPIClient reporting = null, IRuntimeAPIClient runtime = null)
+        internal static Mock<IZenApi> CreateMock(IReportingAPIClient reporting = null, IRuntimeAPIClient runtime = null)
         {
             if (reporting == null)
             {
@@ -40,7 +40,7 @@ namespace Aikido.Zen.Tests.Mocks
             return zenApi;
         }
 
-        public static Mock<IZenApi> CreateMockWithFailedResponses()
+        internal static Mock<IZenApi> CreateMockWithFailedResponses()
         {
             var reportingApiClient = new Mock<IReportingAPIClient>();
             reportingApiClient
@@ -67,7 +67,7 @@ namespace Aikido.Zen.Tests.Mocks
             return zenApi;
         }
 
-        public static Mock<IZenApi> CreateMockWithExceptions()
+        internal static Mock<IZenApi> CreateMockWithExceptions()
         {
             var reportingApiClient = new Mock<IReportingAPIClient>();
             reportingApiClient


### PR DESCRIPTION
IZenApi, IReportingAPIClient, IRuntimeAPIClient and its implementations are internal implementation details of the Zen firewall for .NET.

Marking them internal will prevent them from being used in consumers code.