### PR TITLE
Fix runtime sca

### DIFF
--- a/Aikido.Zen.DotNetCore/Aikido.Zen.DotNetCore.nuspec
+++ b/Aikido.Zen.DotNetCore/Aikido.Zen.DotNetCore.nuspec
@@ -23,6 +23,7 @@
     </frameworkReferences>
     <dependencies>
         <dependency id="Lib.Harmony" version="[2.3.5,)" />
+        <dependency id="Microsoft.Extensions.DependencyModel" version="[6.0.0,)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Runtime SCA failed due to a missing dependency to Microsoft.Extensions.DependencyModel