### PR TITLE
Bug/handle canceled request properly

### DIFF
--- a/Aikido.Zen.Core/Api/Reporting.cs
+++ b/Aikido.Zen.Core/Api/Reporting.cs
@@ -82,10 +82,7 @@ namespace Aikido.Zen.Core.Api
                 }
                 catch (TaskCanceledException)
                 {
-                    if (!cts.Token.IsCancellationRequested)
-                        return new FirewallListsAPIResponse { Success = false, Error = "timeout" };
-
-                    throw;
+                    return new FirewallListsAPIResponse { Success = false, Error = "Request canceled or timed out" };
                 }
                 catch (Exception)
                 {

--- a/Aikido.Zen.Test/ReportingAPiClientTests.cs
+++ b/Aikido.Zen.Test/ReportingAPiClientTests.cs
@@ -158,8 +158,8 @@ namespace Aikido.Zen.Test
                 .Returns(async (HttpRequestMessage req, CancellationToken token) =>
                 {
                     // Simulate waiting for longer than the cancellation timeout
-                    await Task.Delay(10000, token); // Wait 10 seconds or until canceled
-                    return new HttpResponseMessage(); // This line will never execute if token is cancelled
+                    await Task.Delay(10000, token); 
+                    return new HttpResponseMessage();
                 });
 
             var stopwatch = System.Diagnostics.Stopwatch.StartNew();

--- a/Aikido.Zen.Test/ReportingAPiClientTests.cs
+++ b/Aikido.Zen.Test/ReportingAPiClientTests.cs
@@ -77,7 +77,7 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public async Task GetBlockedIps_ShouldReturnSuccess()
+        public async Task GetFirewallLists_ShouldReturnSuccess()
         {
             // Arrange
             var response = new HttpResponseMessage
@@ -112,7 +112,7 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public void GetBlockedIps_ShouldThrowExceptionOnError()
+        public void GetFirewallLists_ShouldThrowExceptionOnError()
         {
             // Arrange
             _handlerMock
@@ -126,6 +126,54 @@ namespace Aikido.Zen.Test
 
             // Act & Assert
             Assert.ThrowsAsync<Exception>(async () => await _reportingApiClient.GetFirewallLists("token"));
+        }
+        [Test]
+        public void GetFirewallLists_ShouldContinueOnCanceledTaskCanceledException()
+        {
+            // Arrange
+            _handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .Throws(new TaskCanceledException("Canceled"));
+
+            // Act & Assert
+            Assert.DoesNotThrowAsync(async () => await _reportingApiClient.GetFirewallLists("token"),"Failed: Task Canceled, but the exception propagated.");
+        }
+
+        [Test]
+        public async Task GetFirewallLists_ShouldContinueOnTimeoutTaskCanceledException()
+        {
+            // Arrange
+            _handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .Returns(async (HttpRequestMessage req, CancellationToken token) =>
+                {
+                    // Simulate waiting for longer than the cancellation timeout
+                    await Task.Delay(10000, token); // Wait 10 seconds or until canceled
+                    return new HttpResponseMessage(); // This line will never execute if token is cancelled
+                });
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            FirewallListsAPIResponse result = new ();
+
+            // Act
+
+            Assert.DoesNotThrowAsync(async () => result = await _reportingApiClient.GetFirewallLists("token"), "Failed: Task timed out, but the exception propagated.");
+
+            stopwatch.Stop();
+
+            // Assert
+            Assert.That(result!.Success, Is.False);
+            Assert.That(stopwatch.ElapsedMilliseconds, Is.InRange( 4500, 7000));
         }
     }
 }


### PR DESCRIPTION
Handle canceled requests when getting Firewall List from Aikido so that we don't throw, but continue execution while returning an appropriate response