### PR TITLE
Display full URL on attack instances

### DIFF
--- a/Aikido.Zen.Core/Helpers/RateLimitingHelper.cs
+++ b/Aikido.Zen.Core/Helpers/RateLimitingHelper.cs
@@ -1,9 +1,9 @@
-using System.Diagnostics;
-using Aikido.Zen.Core.Models;
-using System.Runtime.CompilerServices;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
+
+using Aikido.Zen.Core.Models;
 
 [assembly: InternalsVisibleTo("Aikido.Zen.Test")]
 [assembly: InternalsVisibleTo("Aikido.Zen.Benchmarks")]
@@ -90,11 +90,11 @@ namespace Aikido.Zen.Core.Helpers
 
             // Get the user ID or IP address for the key
             string userOrIp = context.User?.Id ?? context.RemoteAddress ?? "unknown";
-
+            var config = new RateLimitingConfig();
             // Check exact match first if it exists
             if (RouteHelper.HasExactMatch(context, rateLimitedEndpoints, out var exactMatch))
             {
-                var config = exactMatch.RateLimiting;
+                config = exactMatch.RateLimiting;
                 var exactKey = $"{exactMatch.Method}|{exactMatch.Route}:user-or-ip:{userOrIp}";
                 if (!IsAllowed(exactKey, config.WindowSizeInMS, config.MaxRequests))
                 {
@@ -110,7 +110,7 @@ namespace Aikido.Zen.Core.Helpers
             foreach (var endpoint in matchingEndpoints)
             {
 
-                var config = endpoint.RateLimiting;
+                config = endpoint.RateLimiting;
                 if (config != null && config.Enabled)
                 {
                     var matchKey = $"{endpoint.Method}|{endpoint.Route}:user-or-ip:{userOrIp}";
@@ -122,7 +122,7 @@ namespace Aikido.Zen.Core.Helpers
             }
 
             // If we get here, all checks passed
-            return (true, null);
+            return (true, config);
         }
 
         private static long GetCurrentTimestamp()

--- a/Aikido.Zen.Core/Helpers/RouteHelper.cs
+++ b/Aikido.Zen.Core/Helpers/RouteHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+
 using Aikido.Zen.Core.Models;
 
 namespace Aikido.Zen.Core.Helpers

--- a/Aikido.Zen.Core/Helpers/RouteHelper.cs
+++ b/Aikido.Zen.Core/Helpers/RouteHelper.cs
@@ -416,9 +416,16 @@ namespace Aikido.Zen.Core.Helpers
 
         private static string TryParseUrlPath(string url)
         {
-            if(Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri))
-                return uri.AbsolutePath;
-            return url;   
+            try
+            {
+                if (Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri))
+                    return uri.AbsolutePath;
+                return url;
+            }
+            catch
+            {
+                return url;
+            }
         }
     }
 }

--- a/Aikido.Zen.Core/Helpers/RouteHelper.cs
+++ b/Aikido.Zen.Core/Helpers/RouteHelper.cs
@@ -416,15 +416,9 @@ namespace Aikido.Zen.Core.Helpers
 
         private static string TryParseUrlPath(string url)
         {
-            try
-            {
-                Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri);
+            if(Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri))
                 return uri.AbsolutePath;
-            }
-            catch
-            {
-                return url;
-            }
+            return url;   
         }
     }
 }

--- a/Aikido.Zen.Core/Helpers/RouteHelper.cs
+++ b/Aikido.Zen.Core/Helpers/RouteHelper.cs
@@ -264,13 +264,15 @@ namespace Aikido.Zen.Core.Helpers
                 return false;
             }
 
+            var absolutePath = TryParseUrlPath(context.Url);
+
             var specificMethodEndpoints = endpoints.Where(e => e.Method != "*");
             var wildcardMethodEndpoints = endpoints.Where(e => e.Method == "*");
 
             // 1. Check for Exact URL & Exact Method
             endpoint = specificMethodEndpoints.FirstOrDefault(e =>
                     e.Method.Equals(context.Method, StringComparison.OrdinalIgnoreCase) &&
-                    e.Route.Equals(context.Url, StringComparison.OrdinalIgnoreCase));
+                    e.Route.Equals(absolutePath, StringComparison.OrdinalIgnoreCase));
             if (endpoint != null) return true;
 
             // 2. Check for Exact Route & Exact Method
@@ -281,7 +283,7 @@ namespace Aikido.Zen.Core.Helpers
 
             // 3. Check for Exact URL & Wildcard Method
             endpoint = wildcardMethodEndpoints.FirstOrDefault(e =>
-                    e.Route.Equals(context.Url, StringComparison.OrdinalIgnoreCase));
+                    e.Route.Equals(absolutePath, StringComparison.OrdinalIgnoreCase));
             if (endpoint != null) return true;
 
             // 4. Check for Exact Route & Wildcard Method
@@ -415,7 +417,7 @@ namespace Aikido.Zen.Core.Helpers
         {
             try
             {
-                var uri = new Uri(url);
+                Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri);
                 return uri.AbsolutePath;
             }
             catch

--- a/Aikido.Zen.Core/Models/RateLimitingConfig.cs
+++ b/Aikido.Zen.Core/Models/RateLimitingConfig.cs
@@ -3,8 +3,8 @@ namespace Aikido.Zen.Core.Models
 
     public class RateLimitingConfig
     {
-        public bool Enabled { get; set; }
-        public int MaxRequests { get; set; }
-        public int WindowSizeInMS { get; set; }
+        public bool Enabled { get; set; } = false;
+        public int MaxRequests { get; set; } = 0;
+        public int WindowSizeInMS { get; set; } = 0;
     }
 }

--- a/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
@@ -1,74 +1,70 @@
-using System.Collections.Generic;
-using System.Linq;
 using System.Web; // Import for HTML encoding
+
+using Microsoft.AspNetCore.Http;
+
 using Aikido.Zen.Core;
 using Aikido.Zen.Core.Helpers;
 using Aikido.Zen.Core.Models;
-using Microsoft.AspNetCore.Http;
 
-namespace Aikido.Zen.DotNetCore.Middleware
+namespace Aikido.Zen.DotNetCore.Middleware;
+
+/// <summary>
+/// This middleware is used to block incoming requests based on the firewall's configuration
+/// </summary>
+internal class BlockingMiddleware : IMiddleware
 {
-    /// <summary>
-    /// This middleware is used to block incoming requests based on the firewall's configuration
-    /// </summary>
-    internal class BlockingMiddleware : IMiddleware
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {
-        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+        try
         {
-            try
+            LogHelper.DebugLog(Agent.Logger, "Checking if request should be blocked");
+            var agentContext = Agent.Instance.Context;
+            Agent.Instance.SetBlockingMiddlewareInstalled(true);
+
+            // if the context is not found, skip the blocking checks, this likely means that the request is bypassed
+            if (context.Items["Aikido.Zen.Context"] is not Context aikidoContext)
             {
-                LogHelper.DebugLog(Agent.Logger, "Checking if request should be blocked");
-                var agentContext = Agent.Instance.Context;
-                var aikidoContext = context.Items["Aikido.Zen.Context"] as Context;
-                Agent.Instance.SetBlockingMiddlewareInstalled(true);
-
-                // if the context is not found, skip the blocking checks, this likely means that the request is bypassed
-                if (aikidoContext == null)
-                {
-                    // call the next middleware
-                    await next(context);
-                    return;
-                }
-                var user = context.Items["Aikido.Zen.CurrentUser"] as User;
-                if (user != null)
-                {
-                    Agent.Instance.Context.AddUser(user, ipAddress: context.Connection.RemoteIpAddress?.ToString());
-                }
-
-                // block the request if the user is blocked
-                if (Agent.Instance.Context.IsBlocked(aikidoContext, out var reason))
-                {
-                    Agent.Instance.Context.AddAbortedRequest();
-                    context.Response.StatusCode = 403;
-                    LogHelper.DebugLog(Agent.Logger, $"Request blocked: {HttpUtility.HtmlEncode(reason)}");
-                    await context.Response.WriteAsync($"Your request is blocked: {HttpUtility.HtmlEncode(reason)}");
-                    return;
-                }
-
-                // Check if rate limiting should be applied
-                var remoteAddress = HttpUtility.HtmlEncode(aikidoContext.RemoteAddress); // HTML escape the remote address
-
-                // Use the helper to check all rate limiting rules
-                var (isAllowed, effectiveConfig) = RateLimitingHelper.IsRequestAllowed(aikidoContext, agentContext.Endpoints);
-
-                if (!isAllowed)
-                {
-                    Agent.Instance.Context.AddAbortedRequest();
-                    context.Response.StatusCode = 429;
-
-                    if (effectiveConfig != null)
-                    {
-                        context.Response.Headers.Add("Retry-After", effectiveConfig.WindowSizeInMS.ToString());
-                    }
-
-                    await context.Response.WriteAsync($"You are rate limited by Aikido firewall. (Your IP: {remoteAddress})");
-                    return;
-                }
+                // call the next middleware
+                await next(context);
+                return;
             }
-            catch (Exception ex)
+
+            if (context.Items["Aikido.Zen.CurrentUser"] is User user)            
+                Agent.Instance.Context.AddUser(user, ipAddress: context.Connection.RemoteIpAddress?.ToString());
+            
+
+            // block the request if the user is blocked
+            if (Agent.Instance.Context.IsBlocked(aikidoContext, out var reason))
             {
-                LogHelper.ErrorLog(Agent.Logger, $"Error blocking request: {ex.Message}");
+                Agent.Instance.Context.AddAbortedRequest();
+                context.Response.StatusCode = 403;
+                LogHelper.DebugLog(Agent.Logger, $"Request blocked: {HttpUtility.HtmlEncode(reason)}");
+                await context.Response.WriteAsync($"Your request is blocked: {HttpUtility.HtmlEncode(reason)}");
+                return;
             }
+
+            // Check if rate limiting should be applied
+            var remoteAddress = HttpUtility.HtmlEncode(aikidoContext.RemoteAddress); // HTML escape the remote address
+
+            // Use the helper to check all rate limiting rules
+            var (isAllowed, effectiveConfig) = RateLimitingHelper.IsRequestAllowed(aikidoContext, agentContext.Endpoints);
+
+            if (isAllowed)
+                await next(context);
+
+            Agent.Instance.Context.AddAbortedRequest();
+            context.Response.StatusCode = 429;
+
+            if (effectiveConfig.Enabled)            
+                context.Response.Headers.Add("Retry-After", effectiveConfig.WindowSizeInMS.ToString());
+            
+
+            await context.Response.WriteAsync($"You are rate limited by Aikido firewall. (Your IP: {remoteAddress})");
+            return;
+        }
+        catch (Exception ex)
+        {
+            LogHelper.ErrorLog(Agent.Logger, $"Error blocking request: {ex.Message}");
             await next(context);
         }
     }

--- a/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
@@ -50,7 +50,10 @@ internal class BlockingMiddleware : IMiddleware
             var (isAllowed, effectiveConfig) = RateLimitingHelper.IsRequestAllowed(aikidoContext, agentContext.Endpoints);
 
             if (isAllowed)
+            {
                 await next(context);
+                return;
+            }
 
             Agent.Instance.Context.AddAbortedRequest();
             context.Response.StatusCode = 429;

--- a/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
@@ -4,6 +4,7 @@ using Aikido.Zen.Core;
 using Aikido.Zen.Core.Helpers;
 using Aikido.Zen.Core.Models;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 
@@ -121,7 +122,7 @@ namespace Aikido.Zen.DotNetCore.Middleware
                 headersDictionary = new ConcurrentDictionary<string, string[]>(httpContext.Request.Headers.ToDictionary(h => h.Key, h => h.Value.ToArray()));
                 context = new Context
                 {
-                    Url = httpContext.Request.Path.ToString(),
+                    Url = httpContext.Request.GetDisplayUrl(),
                     Method = httpContext.Request.Method,
                     Query = FlattenQueryParameters(httpContext.Request.Query),
                     Headers = FlattenHeaders(httpContext.Request.Headers),

--- a/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
@@ -58,20 +58,19 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                 // Use the helper to check all rate limiting rules
                 var (isAllowed, effectiveConfig) = RateLimitingHelper.IsRequestAllowed(aikidoContext, agentContext.Endpoints);
 
-                if (!isAllowed)
-                {
-                    Agent.Instance.Context.AddAbortedRequest();
-                    httpContext.Response.StatusCode = 429;
-
-                    if (effectiveConfig != null)
-                    {
-                        httpContext.Response.Headers.Add("Retry-After", effectiveConfig.WindowSizeInMS.ToString());
-                    }
-
-                    httpContext.Response.Write($"You are rate limited by Aikido firewall. (Your IP: {aikidoContext.RemoteAddress})");
-                    httpContext.Response.End();
+                if (isAllowed)
                     return;
-                }
+                
+                Agent.Instance.Context.AddAbortedRequest();
+                httpContext.Response.StatusCode = 429;
+
+                if (effectiveConfig.Enabled)
+                    httpContext.Response.Headers.Add("Retry-After", effectiveConfig.WindowSizeInMS.ToString());
+                
+
+                httpContext.Response.Write($"You are rate limited by Aikido firewall. (Your IP: {aikidoContext.RemoteAddress})");
+                httpContext.Response.End();
+                return;
             }
             catch (Exception ex)
             {

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -70,7 +70,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
 
                 var context = new Context
                 {
-                    Url = httpContext.Request.Path,
+                    Url = httpContext.Request.Url.AbsoluteUri,
                     Method = httpContext.Request.HttpMethod,
                     Query = FlattenQueryParameters(httpContext.Request.QueryString),
                     Headers = FlattenHeaders(httpContext.Request.Headers),

--- a/Aikido.Zen.Test/AgentConfigurationTests.cs
+++ b/Aikido.Zen.Test/AgentConfigurationTests.cs
@@ -37,7 +37,7 @@ namespace Aikido.Zen.Test
             {
                 Method = "GET",
                 Route = "/test",
-                Url = "/test",
+                Url = "http://example.com/api/users/123",
                 RemoteAddress = "234.234.234.234"
             };
 

--- a/Aikido.Zen.Test/AgentContextTests.cs
+++ b/Aikido.Zen.Test/AgentContextTests.cs
@@ -200,7 +200,7 @@ namespace Aikido.Zen.Test
             _agentContext.AddRoute(context);
 
             // Assert
-            var route = _agentContext.Routes.FirstOrDefault(r => r.Path == context.Url);
+            var route = _agentContext.Routes.FirstOrDefault(r => r.Path == context.Route);
             Assert.That(route == null, Is.False);
             Assert.That(route.Method, Is.EqualTo(context.Method));
             Assert.That(route.Hits, Is.EqualTo(1));

--- a/Aikido.Zen.Test/AgentContextTests.cs
+++ b/Aikido.Zen.Test/AgentContextTests.cs
@@ -191,7 +191,7 @@ namespace Aikido.Zen.Test
             // Arrange
             var context = new Context
             {
-                Url = "/api/test",
+                Url = "http://example.com/api/test",
                 Method = "GET",
                 Route = "/api/test"
             };
@@ -252,7 +252,7 @@ namespace Aikido.Zen.Test
             // Arrange
             var context = new Context
             {
-                Url = "/api/repeated",
+                Url = "http://example.com/api/repeated",
                 Method = "GET",
                 Route = "/api/repeated"
             };
@@ -297,7 +297,7 @@ namespace Aikido.Zen.Test
             _agentContext.AddUser(new User("user1", "User One"), "192.168.1.1");
             _agentContext.AddRoute(new Context
             {
-                Url = "/api/test",
+                Url = "http://example.com/api/test",
                 Method = "GET"
             });
 
@@ -661,7 +661,7 @@ namespace Aikido.Zen.Test
         {
             // Arrange
             const int MaxRoutes = 5000;
-            var firstRouteContext = new Context { Url = "/route0", Method = "GET", Route = "/route0" };
+            var firstRouteContext = new Context { Url = "http://example.com/route0", Method = "GET", Route = "/route0" };
             _agentContext.Clear();
 
             // Act
@@ -671,7 +671,7 @@ namespace Aikido.Zen.Test
             // Add MaxRoutes more routes, ensuring they all end up with Hits = 2
             for (int i = 1; i <= MaxRoutes; i++)
             {
-                var routeContext = new Context { Url = $"/route{i}", Method = "GET", Route = $"/route{i}" };
+                var routeContext = new Context { Url = $"http://example.com/route{i}", Method = "GET", Route = $"/route{i}" };
                 // AddRoute calls AddOrUpdate internally.
                 // When adding route[MaxRoutes], Size >= MaxRoutes triggers eviction *before* add.
                 // LFU is route0 (Hits=1). route0 is evicted.

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -35,7 +35,7 @@ namespace Aikido.Zen.Test
             var context = new Context
             {
                 User = new User("123", "testUser"),
-                Url = "/test",
+                Url = "http://example.com/test",
                 Method = "GET",
                 RemoteAddress = "127.0.0.1"
             };
@@ -351,7 +351,7 @@ namespace Aikido.Zen.Test
             // Arrange
             var context = new Context
             {
-                Url = "/test",
+                Url = "http://example.com/test",
                 Method = "GET",
                 RemoteAddress = "127.0.0.1"
             };
@@ -374,7 +374,7 @@ namespace Aikido.Zen.Test
             var context = new Context
             {
                 User = user,
-                Url = "/test/path",
+                Url = "http://example.com/test/path",
                 Method = "POST",
                 RemoteAddress = "192.168.1.1"
             };
@@ -570,7 +570,7 @@ namespace Aikido.Zen.Test
             var context = new Context
             {
                 User = new User("123", "userName"),
-                Url = "/test",
+                Url = "http://example.com/test",
                 Route = "/test",
                 Method = "GET",
                 RemoteAddress = "1.2.3.4"
@@ -726,7 +726,7 @@ namespace Aikido.Zen.Test
             // Arrange
             var context = new Context
             {
-                Url = "/test/route",
+                Url = "http://example.com/test/route",
                 Method = "GET",
                 RemoteAddress = "192.168.1.1",
                 Route = "/test/route"

--- a/Aikido.Zen.Test/ApiAuthTypeHelperTests.cs
+++ b/Aikido.Zen.Test/ApiAuthTypeHelperTests.cs
@@ -19,7 +19,7 @@ namespace Aikido.Zen.Test.Helpers
                 Headers = headers ?? new Dictionary<string, string>(),
                 Body = null,
                 RemoteAddress = "",
-                Url = "http://localhost/test",
+                Url = "http://example.com/test",
                 RouteParams = new Dictionary<string, string>(),
                 Query = new Dictionary<string, string>(),
                 Cookies = cookies ?? new Dictionary<string, string>(),

--- a/Aikido.Zen.Test/ApiInfoHelperTests.cs
+++ b/Aikido.Zen.Test/ApiInfoHelperTests.cs
@@ -80,7 +80,7 @@ namespace Aikido.Zen.Test.Helpers
                 Body = bodyStream,
                 Query = query ?? new Dictionary<string, string>(),
                 RemoteAddress = "127.0.0.1",
-                Url = "http://localhost/test",
+                Url = "http://example.com/test",
                 RouteParams = new Dictionary<string, string>(),
                 Cookies = new Dictionary<string, string>(),
                 Source = "test",

--- a/Aikido.Zen.Test/Concurrency.AgentContextTests.cs
+++ b/Aikido.Zen.Test/Concurrency.AgentContextTests.cs
@@ -103,7 +103,7 @@ namespace Aikido.Zen.Test
                     {
                         _agentContext.AddRoute(new Context
                         {
-                            Url = $"/api/test{threadId}-{j}",
+                            Url = $"http://example.com/api/test{threadId}-{j}",
                             Method = "GET",
                             Route = $"/api/test{threadId}-{j}"
                         });
@@ -210,7 +210,7 @@ namespace Aikido.Zen.Test
                         // Add route
                         _agentContext.AddRoute(new Context
                         {
-                            Url = $"/api/test{threadId}-{j}",
+                            Url = $"http://example.com/api/test{threadId}-{j}",
                             Method = "GET",
                             Route = $"/api/test{threadId}-{j}"
                         });

--- a/Aikido.Zen.Test/RatelimitingHelperTests.cs
+++ b/Aikido.Zen.Test/RatelimitingHelperTests.cs
@@ -337,7 +337,7 @@ namespace Aikido.Zen.Test.Helpers
         public void IsRequestAllowed_ShouldRespectExactMatch()
         {
             // Arrange
-            var context = new Context { Method = "GET", Route = "api/{entity}", Url = "api/users" };
+            var context = new Context { Method = "GET", Route = "api/{entity}", Url = "http://example.com/api/users" };
             context.User = new User("user123", "Test User");
 
             var endpoints = new List<EndpointConfig>
@@ -367,7 +367,7 @@ namespace Aikido.Zen.Test.Helpers
         public void IsRequestAllowed_ShouldRespectWildcardMatch()
         {
             // Arrange
-            var context = new Context { Method = "GET", Route = "api/users", Url = "api/users" };
+            var context = new Context { Method = "GET", Route = "api/users", Url = "http://example.com/api/users" };
             context.User = new User("user123", "Test User");
 
             var endpoints = new List<EndpointConfig>

--- a/Aikido.Zen.Test/RatelimitingHelperTests.cs
+++ b/Aikido.Zen.Test/RatelimitingHelperTests.cs
@@ -397,7 +397,7 @@ namespace Aikido.Zen.Test.Helpers
         public void IsRequestAllowed_ShouldRespectMostExactMatch()
         {
             // Arrange
-            var context = new Context { Method = "GET", Route = "api/users" };
+            var context = new Context { Method = "GET", Route = "api/users", Url = "http://test.com/api/users" };
             context.User = new User("user123", "Test User");
 
             var endpoints = new List<EndpointConfig>

--- a/Aikido.Zen.Test/RatelimitingHelperTests.cs
+++ b/Aikido.Zen.Test/RatelimitingHelperTests.cs
@@ -345,7 +345,7 @@ namespace Aikido.Zen.Test.Helpers
                 new EndpointConfig
                 {
                     Method = "GET",
-                    Route = "api/users",
+                    Route = "/api/users",
                     RateLimiting = new RateLimitingConfig { Enabled = true, MaxRequests = 2, WindowSizeInMS = 1000 }
                 }
             };
@@ -375,7 +375,7 @@ namespace Aikido.Zen.Test.Helpers
                 new EndpointConfig
                 {
                     Method = "GET",
-                    Route = "api/*",
+                    Route = "/api/*",
                     RateLimiting = new RateLimitingConfig { Enabled = true, MaxRequests = 2, WindowSizeInMS = 1000 }
                 }
             };

--- a/Aikido.Zen.Test/RouteHelperTests.cs
+++ b/Aikido.Zen.Test/RouteHelperTests.cs
@@ -337,7 +337,7 @@ namespace Aikido.Zen.Test.Helpers
             var context = new Context
             {
                 Method = "POST",
-                Url = "http://localhost:7000/api/users/123",
+                Url = "http://localhost:7000/posts/3",
                 Route = null
             };
             var endpoints = new List<EndpointConfig>

--- a/Aikido.Zen.Test/RouteHelperTests.cs
+++ b/Aikido.Zen.Test/RouteHelperTests.cs
@@ -259,7 +259,7 @@ namespace Aikido.Zen.Test.Helpers
             var context = new Context
             {
                 Method = "POST",
-                Url = "/posts/3",
+                Url = "http://localhost:7000/api/users/123",
                 Route = "/posts/:number"
             };
             var endpoints = new List<EndpointConfig>
@@ -337,7 +337,7 @@ namespace Aikido.Zen.Test.Helpers
             var context = new Context
             {
                 Method = "POST",
-                Url = "/posts/3",
+                Url = "http://localhost:7000/api/users/123",
                 Route = null
             };
             var endpoints = new List<EndpointConfig>
@@ -610,7 +610,7 @@ namespace Aikido.Zen.Test.Helpers
             {
                 Method = "GET",
                 Route = "/api/users/{id}",
-                Url = "/api/users/123"
+                Url = "http://example.com/api/users/123"
             };
 
             var endpoints = new List<EndpointConfig>
@@ -668,7 +668,7 @@ namespace Aikido.Zen.Test.Helpers
             {
                 Method = "GET",
                 Route = "/api/users/{id}",
-                Url = "/api/users/123"
+                Url = "http://localhost:7000/api/users/123"
             };
 
             var endpointPrio1 = new EndpointConfig { Method = "GET", Route = "/api/users/123", RateLimiting = new RateLimitingConfig { Enabled = true } }; // Exact URL & Exact Method
@@ -709,7 +709,7 @@ namespace Aikido.Zen.Test.Helpers
             {
                 Method = "GET",
                 Route = "/api/users/{id}",
-                Url = "/api/users/123"
+                Url = "http://localhost:7000/api/users/123"
             };
             var endpoints = new List<EndpointConfig>
             {
@@ -749,7 +749,7 @@ namespace Aikido.Zen.Test.Helpers
             {
                 Method = "get",
                 Route = "/api/USERS/{id:int}",
-                Url = "/api/USERS/123"
+                Url = "http://localhost:7000/api/users/123"
             };
             var endpoints = new List<EndpointConfig>
             {
@@ -779,7 +779,7 @@ namespace Aikido.Zen.Test.Helpers
             {
                 Method = "GET",
                 Route = "/api/users/{id}",
-                Url = "/api/users/123"
+                Url = "http://localhost:7000/api/users/123"
             };
             var endpoints = new List<EndpointConfig>();
 

--- a/Aikido.Zen.Tests.DotNetCore/ContextMiddlewareTests.cs
+++ b/Aikido.Zen.Tests.DotNetCore/ContextMiddlewareTests.cs
@@ -1,324 +1,346 @@
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Aikido.Zen.Core;
-using Aikido.Zen.Core.Helpers;
-using Aikido.Zen.Core.Models;
 using Aikido.Zen.DotNetCore.Middleware;
-using Aikido.Zen.Tests.Mocks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Moq;
-using NUnit.Framework;
+using System.Collections.Concurrent;
+using System.Reflection;
 
-namespace Aikido.Zen.Tests.DotNetCore
+namespace Aikido.Zen.Tests.DotNetCore;
+
+public class ContextMiddlewareTests
 {
-    public class ContextMiddlewareTests
+    private Mock<HttpContext> _mockHttpContext;
+    private Mock<EndpointDataSource> _mockEndpointDataSource;
+    private ContextMiddleware _contextMiddleware;
+
+    [SetUp]
+    public void Setup()
     {
-        private Mock<HttpContext> _mockHttpContext;
-        private Mock<EndpointDataSource> _mockEndpointDataSource;
-        private ContextMiddleware _contextMiddleware;
-
-        [SetUp]
-        public void Setup()
+        _mockEndpointDataSource = new Mock<EndpointDataSource>();
+        _mockEndpointDataSource.Setup(m => m.Endpoints).Returns(new List<Endpoint>
         {
-            _mockEndpointDataSource = new Mock<EndpointDataSource>();
-            _mockEndpointDataSource.Setup(m => m.Endpoints).Returns(new List<Endpoint>
-            {
-                CreateEndpoint("api/test", "TestEndpoint"),
-                CreateEndpoint("api/items/{id}", "ParameterizedEndpoint"),
-                CreateEndpoint("static/file.js", "StaticFileEndpoint"),
-                CreateEndpoint("api/items/special/{id}", "SpecialParameterizedEndpoint"),
-                CreateEndpoint("api/items/special", "SpecialEndpoint"),
-                CreateEndpoint("api/{version}/items/{id}", "VersionedParameterizedEndpoint"),
-                CreateEndpoint("api/v1/items/{id}", "V1ParameterizedEndpoint"),
-                CreateEndpoint("{slug}", "SlugEndpoint")
-            });
-            _mockHttpContext = new Mock<HttpContext>();
-            _contextMiddleware = new ContextMiddleware([_mockEndpointDataSource.Object]);
-        }
+            CreateEndpoint("api/test", "TestEndpoint"),
+            CreateEndpoint("api/items/{id}", "ParameterizedEndpoint"),
+            CreateEndpoint("static/file.js", "StaticFileEndpoint"),
+            CreateEndpoint("api/items/special/{id}", "SpecialParameterizedEndpoint"),
+            CreateEndpoint("api/items/special", "SpecialEndpoint"),
+            CreateEndpoint("api/{version}/items/{id}", "VersionedParameterizedEndpoint"),
+            CreateEndpoint("api/v1/items/{id}", "V1ParameterizedEndpoint"),
+            CreateEndpoint("{slug}", "SlugEndpoint")
+        });
+        _mockHttpContext = new Mock<HttpContext>();
+        _contextMiddleware = new ContextMiddleware([_mockEndpointDataSource.Object]);
+    }
 
-        private Endpoint CreateEndpoint(string pattern, string name)
+    private Endpoint CreateEndpoint(string pattern, string name)
+    {
+        return new RouteEndpoint(
+            context => Task.CompletedTask,
+            RoutePatternFactory.Parse(pattern),
+            0,
+            new EndpointMetadataCollection
+            (
+                new HttpMethodMetadata(new[] { "GET" }),
+                new RouteValuesAddressMetadata(pattern)
+            ),
+            name);
+    }
+
+    [Test]
+    public void GetParametrizedRoute_ReturnsCorrectRoutePattern()
+    {
+        // Arrange
+        _mockHttpContext.Setup(c => c.Request.Path).Returns("/api/test");
+
+        // Act
+        var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+
+        // Assert
+        Assert.That("/api/test", Is.EqualTo(route));
+    }
+
+    [Test]
+    public void GetParametrizedRoute_ReturnsCorrectRoutePattern_WithRouteParameters()
+    {
+        // Arrange
+        _mockHttpContext.Setup(c => c.Request.Path).Returns("/api/items/123");
+        // Act
+        var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+
+        // Assert
+        Assert.That("/api/items/{id}", Is.EqualTo(route));
+    }
+
+    [Test]
+    public void GetParametrizedRoute_ReturnsCorrectRoutePattern_ForStaticFiles()
+    {
+        _mockHttpContext.Setup(c => c.Request.Path).Returns("/static/file.js");
+
+        // Act
+        var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+
+        // Assert
+        Assert.That("/static/file.js", Is.EqualTo(route));
+    }
+
+    [Test]
+    public void GetParametrizedRoute_ReturnsForwardSlash_ForNullPath()
+    {
+        // Arrange
+        _mockHttpContext.Setup(c => c.Request.Path).Returns((string)null);
+
+        // Act
+        var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+
+        // Assert
+        Assert.That("/", Is.EqualTo(route));
+    }
+
+    [Test]
+    public void GetParametrizedRoute_ReturnsMostSpecificRoutePattern_WhenMultipleRoutesMatch()
+    {
+        // Arrange
+        _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/items/special/123"));
+
+        // Act
+        var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+
+        // Assert
+        Assert.That("/api/items/special/{id}", Is.EqualTo(route));
+    }
+
+    [Test]
+    public void GetParametrizedRoute_ReturnsMostSpecificRoutePattern_WhenMultipleRoutesWithAndWithoutParametersMatch()
+    {
+        // Arrange
+        _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/items/special"));
+
+        // Act
+        var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+
+        // Assert
+        Assert.That("/api/items/special", Is.EqualTo(route));
+    }
+
+    [Test]
+    public void GetParametrizedRoute_ReturnsMostSpecificRoutePattern_WhenMultipleRoutesWithDifferentDepthsMatch()
+    {
+        // Arrange
+        _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/v1/items/123"));
+
+        // Act
+        var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+
+        // Assert
+        Assert.That(route, Is.EqualTo("/api/v1/items/{id}"), "The route pattern should match the most specific route with the correct parameter");
+    }
+
+    [Test]
+    public void GetParametrizedRoute_ReturnsParameterizedRoute_WhenNoRouteFound()
+    {
+        // Arrange
+        _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/users/123/posts/abc123dEf456"));
+        _mockHttpContext.Setup(c => c.Request.Scheme).Returns("http");
+        _mockHttpContext.Setup(c => c.Request.Host).Returns(new HostString("test.local"));
+
+        // Act
+        var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+
+        // Assert
+        Assert.That(route, Is.EqualTo("/api/users/:number/posts/:secret"));
+    }
+
+    [Test]
+    public void GetParametrizedRoute_ReturnsParameterizedRoute_ForEmailAddress()
+    {
+        // Arrange
+        _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/users/john.doe@example.com"));
+        _mockHttpContext.Setup(c => c.Request.Scheme).Returns("http");
+        _mockHttpContext.Setup(c => c.Request.Host).Returns(new HostString("test.local"));
+
+        // Act
+        var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+
+        // Assert
+        Assert.That(route, Is.EqualTo("/api/users/:email"));
+    }
+
+    [Test]
+    public void GetParametrizedRoute_ReturnsParameterizedRoute_ForUUID()
+    {
+        // Arrange
+        _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/users/109156be-c4fb-41ea-b1b4-efe1671c5836"));
+        _mockHttpContext.Setup(c => c.Request.Scheme).Returns("http");
+        _mockHttpContext.Setup(c => c.Request.Host).Returns(new HostString("test.local"));
+
+        // Act
+        var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+
+        // Assert
+        Assert.That(route, Is.EqualTo("/api/users/:uuid"));
+    }
+
+    [Test]
+    public void GetParametrizedRoute_ReturnsOriginalUrl_WhenPathIsSingleSegment()
+    {
+        // Arrange
+        // Clear specific endpoints, use only default fallback logic
+        _mockEndpointDataSource.Setup(m => m.Endpoints).Returns(new List<Endpoint>());
+        _mockHttpContext.Setup(c => c.Request.Scheme).Returns("http");
+        _mockHttpContext.Setup(c => c.Request.Host).Returns(new HostString("test.local"));
+
+        // Act & Assert
+
+        // Test case where the path segment *is* a parameter type recognized by BuildRouteFromUrl (like UUID)
+        _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/109156be-c4fb-41ea-b1b4-efe1671c5836"));
+        var routeUuid = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+        Assert.That(routeUuid, Is.EqualTo("/109156be-c4fb-41ea-b1b4-efe1671c5836")); // PathIsSingleSegment would return true for /:uuid
+
+        // Test case where the path segment is *not* a parameter type recognized by BuildRouteFromUrl
+        // but might be considered a slug
+        _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/simple-slug"));
+        var routeSlug = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+        Assert.That(routeSlug, Is.EqualTo("/simple-slug")); // PathIsSingleSegment would return false for /simple-slug
+
+        // Test case where PathIsSingleRouteParameter would be false (multiple segments)
+        _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/users/123/profile"));
+        var routeMultiSegment = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+        Assert.That(routeMultiSegment, Is.EqualTo("/users/:number/profile")); // PathIsSingleSegment would return false for /users/:number/profile
+
+        // Test case for API prefix which should be ignored by PathIsSingleSegment
+        _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/v1/109156be-c4fb-41ea-b1b4-efe1671c5836"));
+        var routeApiUuid = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+        // BuildRouteFromUrl handles the full path including /api/v1/
+        Assert.That(routeApiUuid, Is.EqualTo("/api/v1/:uuid")); // PathIsSingleSegment would return true for /:uuid (after stripping prefix)
+
+        // Restore endpoints for other tests if needed (though Setup runs before each test)
+        _mockEndpointDataSource.Setup(m => m.Endpoints).Returns(new List<Endpoint>
         {
-            return new RouteEndpoint(
-                context => Task.CompletedTask,
-                RoutePatternFactory.Parse(pattern),
-                0,
-                new EndpointMetadataCollection
-                (
-                    new HttpMethodMetadata(new[] { "GET" }),
-                    new RouteValuesAddressMetadata(pattern)
-                ),
-                name);
-        }
+            CreateEndpoint("api/test", "TestEndpoint"),
+            // ... potentially add back other endpoints if needed for subsequent tests in the same run, though usually not necessary with [SetUp]
+        });
+    }
 
-        [Test]
-        public void GetParametrizedRoute_ReturnsCorrectRoutePattern()
+    [Test]
+    public void FlattenQueryParameters_FlattensSingleParameter()
+    {
+        // Arrange
+        var mockQuery = new Mock<IQueryCollection>();
+        var queryDict = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
         {
-            // Arrange
-            _mockHttpContext.Setup(c => c.Request.Path).Returns("/api/test");
+            { "param1", "value1" }
+        };
+        mockQuery.Setup(x => x.GetEnumerator()).Returns(queryDict.GetEnumerator());
 
-            // Act
-            var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+        // Act
+        var method = typeof(ContextMiddleware).GetMethod("FlattenQueryParameters", BindingFlags.NonPublic | BindingFlags.Static);
+        var result = (IDictionary<string, string>)method.Invoke(null, new object[] { mockQuery.Object });
 
-            // Assert
-            Assert.That("/api/test", Is.EqualTo(route));
-        }
+        // Assert
+        Assert.That(result.ContainsKey("param1"), Is.True);
+        Assert.That(result["param1"], Is.EqualTo("value1"));
+    }
 
-        [Test]
-        public void GetParametrizedRoute_ReturnsCorrectRoutePattern_WithRouteParameters()
+    [Test]
+    public void FlattenQueryParameters_FlattensMultipleParameters()
+    {
+        // Arrange
+        var mockQuery = new Mock<IQueryCollection>();
+        var queryDict = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
         {
-            // Arrange
-            _mockHttpContext.Setup(c => c.Request.Path).Returns("/api/items/123");
-            // Act
-            var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+            { "param1", new Microsoft.Extensions.Primitives.StringValues(new[] { "value1", "value2", "value3" }) }
+        };
+        mockQuery.Setup(x => x.GetEnumerator()).Returns(queryDict.GetEnumerator());
 
-            // Assert
-            Assert.That("/api/items/{id}", Is.EqualTo(route));
-        }
+        // Act
+        var method = typeof(ContextMiddleware).GetMethod("FlattenQueryParameters", BindingFlags.NonPublic | BindingFlags.Static);
+        var result = (IDictionary<string, string>)method.Invoke(null, new object[] { mockQuery.Object });
 
-        [Test]
-        public void GetParametrizedRoute_ReturnsCorrectRoutePattern_ForStaticFiles()
+        // Assert
+        Assert.That(result.ContainsKey("param1"), Is.True);
+        Assert.That(result["param1"], Is.EqualTo("value1"));
+        Assert.That(result.ContainsKey("param1[1]"), Is.True);
+        Assert.That(result["param1[1]"], Is.EqualTo("value2"));
+        Assert.That(result.ContainsKey("param1[2]"), Is.True);
+        Assert.That(result["param1[2]"], Is.EqualTo("value3"));
+    }
+
+    [Test]
+    public void FlattenHeaders_FlattensSingleHeader()
+    {
+        // Arrange
+        var mockHeaders = new Mock<IHeaderDictionary>();
+        var headerDict = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
         {
-            _mockHttpContext.Setup(c => c.Request.Path).Returns("/static/file.js");
+            { "X-Custom-Header", "custom-value" }
+        };
+        mockHeaders.Setup(x => x.GetEnumerator()).Returns(headerDict.GetEnumerator());
 
-            // Act
-            var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+        // Act
+        var method = typeof(ContextMiddleware).GetMethod("FlattenHeaders", BindingFlags.NonPublic | BindingFlags.Static);
+        var result = (IDictionary<string, string>)method.Invoke(null, new object[] { mockHeaders.Object });
 
-            // Assert
-            Assert.That("/static/file.js", Is.EqualTo(route));
-        }
+        // Assert
+        Assert.That(result.ContainsKey("X-Custom-Header"), Is.True);
+        Assert.That(result["X-Custom-Header"], Is.EqualTo("custom-value"));
+    }
 
-        [Test]
-        public void GetParametrizedRoute_ReturnsForwardSlash_ForNullPath()
+    [Test]
+    public void FlattenHeaders_FlattensMultipleHeaders()
+    {
+        // Arrange
+        var mockHeaders = new Mock<IHeaderDictionary>();
+        var headerDict = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
         {
-            // Arrange
-            _mockHttpContext.Setup(c => c.Request.Path).Returns((string)null);
+            { "Accept", new Microsoft.Extensions.Primitives.StringValues(new[] { "text/html", "application/json", "application/xml" }) }
+        };
+        mockHeaders.Setup(x => x.GetEnumerator()).Returns(headerDict.GetEnumerator());
 
-            // Act
-            var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+        // Act
+        var method = typeof(ContextMiddleware).GetMethod("FlattenHeaders", BindingFlags.NonPublic | BindingFlags.Static);
+        var result = (IDictionary<string, string>)method.Invoke(null, new object[] { mockHeaders.Object });
 
-            // Assert
-            Assert.That("/", Is.EqualTo(route));
-        }
+        // Assert
+        Assert.That(result.ContainsKey("Accept"), Is.True);
+        Assert.That(result["Accept"], Is.EqualTo("text/html"));
+        Assert.That(result.ContainsKey("Accept[1]"), Is.True);
+        Assert.That(result["Accept[1]"], Is.EqualTo("application/json"));
+        Assert.That(result.ContainsKey("Accept[2]"), Is.True);
+        Assert.That(result["Accept[2]"], Is.EqualTo("application/xml"));
+    }
 
-        [Test]
-        public void GetParametrizedRoute_ReturnsMostSpecificRoutePattern_WhenMultipleRoutesMatch()
-        {
-            // Arrange
-            _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/items/special/123"));
+    [Test]
+    public void TryPrepareContext_SetsUrl_ToFullUrl()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString("example.com");
+        httpContext.Request.Path = "/api/values";
+        httpContext.Request.QueryString = new QueryString("?foo=bar");
+        
 
-            // Act
-            var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+        var middleware = new ContextMiddleware(Enumerable.Empty<EndpointDataSource>());
+        var method = typeof(ContextMiddleware).GetMethod(
+            "TryPrepareContext",
+            BindingFlags.Instance | BindingFlags.NonPublic);
 
-            // Assert
-            Assert.That("/api/items/special/{id}", Is.EqualTo(route));
-        }
+        Assert.NotNull(method);
 
-        [Test]
-        public void GetParametrizedRoute_ReturnsMostSpecificRoutePattern_WhenMultipleRoutesWithAndWithoutParametersMatch()
-        {
-            // Arrange
-            _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/items/special"));
+        var args = new object?[] { httpContext, null, null, null };
 
-            // Act
-            var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
+        // Act
+        var result = (bool)(method!.Invoke(middleware, args) ?? false);
 
-            // Assert
-            Assert.That("/api/items/special", Is.EqualTo(route));
-        }
+        // Assert
+        Assert.True(result);
+        Assert.That(args[1], Is.TypeOf<ConcurrentDictionary<string, string[]>>());
+        Assert.That(args[2], Is.TypeOf<ConcurrentDictionary<string, string[]>>());
+        Assert.That(args[3], Is.TypeOf<Context>());
+        var ctx = args[3] as Context;
 
-        [Test]
-        public void GetParametrizedRoute_ReturnsMostSpecificRoutePattern_WhenMultipleRoutesWithDifferentDepthsMatch()
-        {
-            // Arrange
-            _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/v1/items/123"));
-
-            // Act
-            var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
-
-            // Assert
-            Assert.That(route, Is.EqualTo("/api/v1/items/{id}"), "The route pattern should match the most specific route with the correct parameter");
-        }
-
-        [Test]
-        public void GetParametrizedRoute_ReturnsParameterizedRoute_WhenNoRouteFound()
-        {
-            // Arrange
-            _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/users/123/posts/abc123dEf456"));
-            _mockHttpContext.Setup(c => c.Request.Scheme).Returns("http");
-            _mockHttpContext.Setup(c => c.Request.Host).Returns(new HostString("test.local"));
-
-            // Act
-            var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
-
-            // Assert
-            Assert.That(route, Is.EqualTo("/api/users/:number/posts/:secret"));
-        }
-
-        [Test]
-        public void GetParametrizedRoute_ReturnsParameterizedRoute_ForEmailAddress()
-        {
-            // Arrange
-            _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/users/john.doe@example.com"));
-            _mockHttpContext.Setup(c => c.Request.Scheme).Returns("http");
-            _mockHttpContext.Setup(c => c.Request.Host).Returns(new HostString("test.local"));
-
-            // Act
-            var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
-
-            // Assert
-            Assert.That(route, Is.EqualTo("/api/users/:email"));
-        }
-
-        [Test]
-        public void GetParametrizedRoute_ReturnsParameterizedRoute_ForUUID()
-        {
-            // Arrange
-            _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/users/109156be-c4fb-41ea-b1b4-efe1671c5836"));
-            _mockHttpContext.Setup(c => c.Request.Scheme).Returns("http");
-            _mockHttpContext.Setup(c => c.Request.Host).Returns(new HostString("test.local"));
-
-            // Act
-            var route = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
-
-            // Assert
-            Assert.That(route, Is.EqualTo("/api/users/:uuid"));
-        }
-
-        [Test]
-        public void GetParametrizedRoute_ReturnsOriginalUrl_WhenPathIsSingleSegment()
-        {
-            // Arrange
-            // Clear specific endpoints, use only default fallback logic
-            _mockEndpointDataSource.Setup(m => m.Endpoints).Returns(new List<Endpoint>());
-            _mockHttpContext.Setup(c => c.Request.Scheme).Returns("http");
-            _mockHttpContext.Setup(c => c.Request.Host).Returns(new HostString("test.local"));
-
-            // Act & Assert
-
-            // Test case where the path segment *is* a parameter type recognized by BuildRouteFromUrl (like UUID)
-            _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/109156be-c4fb-41ea-b1b4-efe1671c5836"));
-            var routeUuid = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
-            Assert.That(routeUuid, Is.EqualTo("/109156be-c4fb-41ea-b1b4-efe1671c5836")); // PathIsSingleSegment would return true for /:uuid
-
-            // Test case where the path segment is *not* a parameter type recognized by BuildRouteFromUrl
-            // but might be considered a slug
-            _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/simple-slug"));
-            var routeSlug = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
-            Assert.That(routeSlug, Is.EqualTo("/simple-slug")); // PathIsSingleSegment would return false for /simple-slug
-
-            // Test case where PathIsSingleRouteParameter would be false (multiple segments)
-            _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/users/123/profile"));
-            var routeMultiSegment = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
-            Assert.That(routeMultiSegment, Is.EqualTo("/users/:number/profile")); // PathIsSingleSegment would return false for /users/:number/profile
-
-            // Test case for API prefix which should be ignored by PathIsSingleSegment
-            _mockHttpContext.Setup(c => c.Request.Path).Returns(new PathString("/api/v1/109156be-c4fb-41ea-b1b4-efe1671c5836"));
-            var routeApiUuid = _contextMiddleware.GetParametrizedRoute(_mockHttpContext.Object);
-            // BuildRouteFromUrl handles the full path including /api/v1/
-            Assert.That(routeApiUuid, Is.EqualTo("/api/v1/:uuid")); // PathIsSingleSegment would return true for /:uuid (after stripping prefix)
-
-            // Restore endpoints for other tests if needed (though Setup runs before each test)
-            _mockEndpointDataSource.Setup(m => m.Endpoints).Returns(new List<Endpoint>
-            {
-                CreateEndpoint("api/test", "TestEndpoint"),
-                // ... potentially add back other endpoints if needed for subsequent tests in the same run, though usually not necessary with [SetUp]
-            });
-        }
-
-        [Test]
-        public void FlattenQueryParameters_FlattensSingleParameter()
-        {
-            // Arrange
-            var mockQuery = new Mock<IQueryCollection>();
-            var queryDict = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
-            {
-                { "param1", "value1" }
-            };
-            mockQuery.Setup(x => x.GetEnumerator()).Returns(queryDict.GetEnumerator());
-
-            // Act
-            var method = typeof(ContextMiddleware).GetMethod("FlattenQueryParameters", BindingFlags.NonPublic | BindingFlags.Static);
-            var result = (IDictionary<string, string>)method.Invoke(null, new object[] { mockQuery.Object });
-
-            // Assert
-            Assert.That(result.ContainsKey("param1"), Is.True);
-            Assert.That(result["param1"], Is.EqualTo("value1"));
-        }
-
-        [Test]
-        public void FlattenQueryParameters_FlattensMultipleParameters()
-        {
-            // Arrange
-            var mockQuery = new Mock<IQueryCollection>();
-            var queryDict = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
-            {
-                { "param1", new Microsoft.Extensions.Primitives.StringValues(new[] { "value1", "value2", "value3" }) }
-            };
-            mockQuery.Setup(x => x.GetEnumerator()).Returns(queryDict.GetEnumerator());
-
-            // Act
-            var method = typeof(ContextMiddleware).GetMethod("FlattenQueryParameters", BindingFlags.NonPublic | BindingFlags.Static);
-            var result = (IDictionary<string, string>)method.Invoke(null, new object[] { mockQuery.Object });
-
-            // Assert
-            Assert.That(result.ContainsKey("param1"), Is.True);
-            Assert.That(result["param1"], Is.EqualTo("value1"));
-            Assert.That(result.ContainsKey("param1[1]"), Is.True);
-            Assert.That(result["param1[1]"], Is.EqualTo("value2"));
-            Assert.That(result.ContainsKey("param1[2]"), Is.True);
-            Assert.That(result["param1[2]"], Is.EqualTo("value3"));
-        }
-
-        [Test]
-        public void FlattenHeaders_FlattensSingleHeader()
-        {
-            // Arrange
-            var mockHeaders = new Mock<IHeaderDictionary>();
-            var headerDict = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
-            {
-                { "X-Custom-Header", "custom-value" }
-            };
-            mockHeaders.Setup(x => x.GetEnumerator()).Returns(headerDict.GetEnumerator());
-
-            // Act
-            var method = typeof(ContextMiddleware).GetMethod("FlattenHeaders", BindingFlags.NonPublic | BindingFlags.Static);
-            var result = (IDictionary<string, string>)method.Invoke(null, new object[] { mockHeaders.Object });
-
-            // Assert
-            Assert.That(result.ContainsKey("X-Custom-Header"), Is.True);
-            Assert.That(result["X-Custom-Header"], Is.EqualTo("custom-value"));
-        }
-
-        [Test]
-        public void FlattenHeaders_FlattensMultipleHeaders()
-        {
-            // Arrange
-            var mockHeaders = new Mock<IHeaderDictionary>();
-            var headerDict = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
-            {
-                { "Accept", new Microsoft.Extensions.Primitives.StringValues(new[] { "text/html", "application/json", "application/xml" }) }
-            };
-            mockHeaders.Setup(x => x.GetEnumerator()).Returns(headerDict.GetEnumerator());
-
-            // Act
-            var method = typeof(ContextMiddleware).GetMethod("FlattenHeaders", BindingFlags.NonPublic | BindingFlags.Static);
-            var result = (IDictionary<string, string>)method.Invoke(null, new object[] { mockHeaders.Object });
-
-            // Assert
-            Assert.That(result.ContainsKey("Accept"), Is.True);
-            Assert.That(result["Accept"], Is.EqualTo("text/html"));
-            Assert.That(result.ContainsKey("Accept[1]"), Is.True);
-            Assert.That(result["Accept[1]"], Is.EqualTo("application/json"));
-            Assert.That(result.ContainsKey("Accept[2]"), Is.True);
-            Assert.That(result["Accept[2]"], Is.EqualTo("application/xml"));
-        }
+        Assert.AreEqual("https://example.com/api/values?foo=bar", ctx.Url);
     }
 }


### PR DESCRIPTION
UpdateD ContextMiddleware and ContextModule to construct the context with a full URL

In RouteHelper parse the URL before matching.
Updated the URL parsing to use TryParse which can't throw.

Update tests to use full URLs in context. Add a test to check if full URL is assigned to the context.

Update RateLimiterHelper to not return null. Update RateLimitingConfig to have default values.

Refactor BlockingMiddleware and BlockingModule to reduce nesting and use RateLimitingConfig.Enabled.