### PR TITLE
Fix provider reporting for AI Usage

### DIFF
--- a/Aikido.Zen.Core/Patches/LLMPatcher.cs
+++ b/Aikido.Zen.Core/Patches/LLMPatcher.cs
@@ -44,13 +44,18 @@ namespace Aikido.Zen.Core.Patches
                     LogHelper.ErrorLog(Agent.Logger, $"Failed to extract model from LLM result for model: {model}");
                 }
 
+                if (!TryGetCloudProvider($"{model} {assembly} {result.GetType().ToString()}", out var provider))
+                {
+                    LogHelper.ErrorLog(Agent.Logger, $"Failed to extract provider from LLM for model: {model}, provider: {provider}");
+                }
+
                 if (!TryExtractTokensFromResult(result, out var tokens))
                 {
-                    LogHelper.ErrorLog(Agent.Logger, $"Failed to extract token usage from LLM result for provider: {assembly}, model: {model}");
+                    LogHelper.ErrorLog(Agent.Logger, $"Failed to extract token usage from LLM result for provider: {provider}, model: {model}");
                 }
 
                 // Record AI statistics
-                Agent.Instance.Context.OnAiCall(assembly, model, tokens.inputTokens, tokens.outputTokens, context.Route);
+                Agent.Instance.Context.OnAiCall(provider, model, tokens.inputTokens, tokens.outputTokens, context.Route);
 
 
                 // record sink statistics


### PR DESCRIPTION
- Reverts the provider reporting logic changed in [this commit](https://github.com/AikidoSec/firewall-dotnet/commit/6773ad9daf1363937f167b5f26d44aabad9f37fb)
- Needed for correct AI Usage reporting and cost estimation