### PR TITLE
Update ApiInfoHelper.cs

### DIFF
--- a/Aikido.Zen.Core/Helpers/OpenAPI/ApiInfoHelper.cs
+++ b/Aikido.Zen.Core/Helpers/OpenAPI/ApiInfoHelper.cs
@@ -81,6 +81,9 @@ namespace Aikido.Zen.Core.Helpers.OpenAPI
 
                 var existingSpec = existingRoute.ApiSpec;
 
+                if(existingSpec == null)
+                    return;
+
                 // Merge body schemas
                 if (existingSpec.Body != null && newInfo.Body != null)
                 {


### PR DESCRIPTION
ExisitingSpec can be null, when the route is not in the api schema or using a non api route (razor pages)

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Prevented null reference by returning when existing route spec was null


<sup>[More info](https://app.aikido.dev/featurebranch/scan/74319613?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->