### PR TITLE
Normalize route pattern ending slash

### DIFF
--- a/Aikido.Zen.Core/Helpers/RouteHelper.cs
+++ b/Aikido.Zen.Core/Helpers/RouteHelper.cs
@@ -108,6 +108,22 @@ namespace Aikido.Zen.Core.Helpers
         };
 
         /// <summary>
+        /// Normalizes a route pattern string by ensuring it starts with a slash but doesn't end with one.
+        /// This is because ASP.NET will trim the ending slash in routes to find the original endpoint.
+        /// </summary>
+        /// <param name="routePattern">The route pattern string to normalize.</param>
+        /// <returns>A normalized route pattern string.</returns>
+        public static string NormalizeRoutePattern(string routePattern)
+        {
+            if (string.IsNullOrEmpty(routePattern))
+            {
+                return "/";
+            }
+
+            return "/" + routePattern.TrimStart('/').TrimEnd('/');
+        }
+
+        /// <summary>
         /// Matches a route pattern against an actual URL path
         /// </summary>
         /// <param name="pattern">The route pattern (e.g. "api/users/{id}")</param>

--- a/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
@@ -243,20 +243,12 @@ namespace Aikido.Zen.DotNetCore.Middleware
         /// <returns>A parameterized route string, always starting with a leading slash</returns>
         internal string GetParametrizedRoute(HttpContext context)
         {
-            var routePattern = context.Request.Path.Value;
-
-            if (string.IsNullOrEmpty(routePattern))
-            {
-                return "/";
-            }
-
-            // Ensure the request path starts with a slash for consistency
-            routePattern = "/" + routePattern.TrimStart('/');
+            var routePattern = RouteHelper.NormalizeRoutePattern(context.Request.Path.Value);
 
             // Check for an exact match endpoint
             var frameworkRoutes = _endpoints
                 .OfType<RouteEndpoint>()
-                .Select(e => GetRoutePattern(e))
+                .Select(e => RouteHelper.NormalizeRoutePattern(e?.RoutePattern.RawText))
                 .ToList();
 
             var exactEndpoint = frameworkRoutes.FirstOrDefault(rp => rp == routePattern);
@@ -299,22 +291,6 @@ namespace Aikido.Zen.DotNetCore.Middleware
 
                 return routePattern;
             }
-        }
-
-        /// <summary>
-        /// Normalizes an endpoint route pattern string by ensuring it starts with a leading slash.
-        /// Returns "/" if the endpoint or its pattern is null/empty.
-        /// </summary>
-        /// <param name="endpoint">The RouteEndpoint to normalize.</param>
-        /// <returns>A normalized route pattern string starting with "/".</returns>
-        private static string GetRoutePattern(RouteEndpoint endpoint)
-        {
-            var pattern = endpoint?.RoutePattern.RawText;
-            if (string.IsNullOrEmpty(pattern))
-            {
-                return "/";
-            }
-            return "/" + pattern.TrimStart('/');
         }
     }
 }

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -226,18 +226,11 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
         /// <returns>A parameterized route string with a leading slash</returns>
         internal string GetParametrizedRoute(HttpContext context)
         {
-            var routePattern = context.Request.Path;
-            if (string.IsNullOrEmpty(routePattern))
-            {
-                return "/";
-            }
-
-            // Ensure the request path starts with a slash for consistency
-            routePattern = "/" + routePattern.TrimStart('/');
+            var routePattern = RouteHelper.NormalizeRoutePattern(context.Request.Path);
 
             // Check for an exact match endpoint
             var frameworkRoutes = RouteTable.Routes.Cast<RouteBase>()
-                .Select(route => GetRoutePattern(route))
+                .Select(route => RouteHelper.NormalizeRoutePattern((route as System.Web.Routing.Route)?.Url))
                 .ToList();
 
             var exactEndpoint = frameworkRoutes.FirstOrDefault(rp => rp == routePattern);
@@ -278,17 +271,6 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
             }
 
             return routePattern;
-        }
-
-        private string GetRoutePattern(RouteBase route)
-        {
-            string routePattern = null;
-            if (route is System.Web.Routing.Route)
-            {
-                routePattern = (route as System.Web.Routing.Route).Url;
-            }
-            // ensure the leading slash from the route pattern, to ensure we don't distinguish for example between api/users and /api/users
-            return "/" + routePattern?.TrimStart('/');
         }
     }
 }


### PR DESCRIPTION
- Normalize route pattern ending slash for consistency with ASP.NET routing
- Move normalization into RouteHelper for deduplication
- Should fix e2e tests regarding rate limiting

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added NormalizeRoutePattern method to normalize route pattern trailing slashes

**📚 Documentation**
* Added XML documentation comments for NormalizeRoutePattern behavior and rationale


<sup>[More info](https://app.aikido.dev/featurebranch/scan/77193147?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->