### PR TITLE
Add '%' dangerous char to shell injection detector

### DIFF
--- a/Aikido.Zen.Core/Vulnerabilities/ShellInjectionDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/ShellInjectionDetector.cs
@@ -16,7 +16,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
         private static readonly char[] separators = { ' ', '\t', '\n', ';', '&', '|', '(', ')', '<', '>' };
 
         // Define dangerous characters and commands as static fields
-        private static readonly char[] dangerousChars = { '#', '!', '"', '$', '&', '\'', '(', ')', '*', ';', '<', '=', '>', '?', '[', '\\', ']', '^', '`', '{', '|', '}', ' ', '\n', '\t', '~' };
+        private static readonly char[] dangerousChars = { '#', '!', '"', '$', '&', '\'', '(', ')', '*', ';', '<', '=', '>', '?', '[', '\\', ']', '^', '`', '{', '|', '}', ' ', '\n', '\t', '~', '%' };
         private static readonly string[] dangerousCommands = { "sleep", "shutdown", "reboot", "poweroff", "halt", "ifconfig", "chmod", "chown", "ping", "ssh", "scp", "curl", "wget", "telnet", "kill", "killall", "rm", "mv", "cp", "touch", "echo", "cat", "head", "tail", "grep", "find", "awk", "sed", "sort", "uniq", "wc", "ls", "env", "ps", "who", "whoami", "id", "w", "df", "du", "pwd", "uname", "hostname", "netstat", "passwd", "arch", "printenv", "logname", "pstree", "hostnamectl", "set", "lsattr", "killall5", "dmesg", "history", "free", "uptime", "finger", "top", "shopt", ":" };
         private static readonly char[] dangerousCharsInsideDoubleQuotes = { '$', '`', '\\', '!' };
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added '%' character to dangerous shell characters detection list


<sup>[More info](https://app.aikido.dev/featurebranch/scan/80310612?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->