### PR TITLE
GetHostEntry can throw sometimes

### DIFF
--- a/Aikido.Zen.Core/Helpers/IPHelper.cs
+++ b/Aikido.Zen.Core/Helpers/IPHelper.cs
@@ -67,9 +67,17 @@ namespace Aikido.Zen.Core.Helpers
         {
             get
             {
-                IPHostEntry ipHostInfo = Dns.GetHostEntry(Dns.GetHostName());
-                IPAddress ipAddress = ipHostInfo.AddressList.FirstOrDefault(ip => ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork);
-                return ipAddress?.ToString() ?? "127.0.0.1";
+                try
+                {
+                    IPHostEntry ipHostInfo = Dns.GetHostEntry(Dns.GetHostName());
+                    IPAddress ipAddress = ipHostInfo.AddressList.FirstOrDefault(ip => ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork);
+                    return ipAddress?.ToString() ?? "127.0.0.1";
+                }
+                catch (Exception)
+                {
+                    // GetHostEntry can throw "SocketException: nodename nor servname provided, or not known"
+                    return "127.0.0.1";
+                }
             }
         }
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Added exception handling around Dns.GetHostEntry to return localhost


<sup>[More info](https://app.aikido.dev/featurebranch/scan/82324182?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->