### PR TITLE
Add \r and \f as both shell separators and dangerous commands

### DIFF
--- a/Aikido.Zen.Core/Vulnerabilities/ShellInjectionDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/ShellInjectionDetector.cs
@@ -13,10 +13,10 @@ namespace Aikido.Zen.Core.Vulnerabilities
     public class ShellInjectionDetector
     {
         private static readonly string[] pathPrefixes = { "/bin/", "/sbin/", "/usr/bin/", "/usr/sbin/", "/usr/local/bin/", "/usr/local/sbin/" };
-        private static readonly char[] separators = { ' ', '\t', '\n', ';', '&', '|', '(', ')', '<', '>' };
+        private static readonly char[] separators = { ' ', '\t', '\n', ';', '&', '|', '(', ')', '<', '>', '\r', '\f' };
 
         // Define dangerous characters and commands as static fields
-        private static readonly char[] dangerousChars = { '#', '!', '"', '$', '&', '\'', '(', ')', '*', ';', '<', '=', '>', '?', '[', '\\', ']', '^', '`', '{', '|', '}', ' ', '\n', '\t', '~' };
+        private static readonly char[] dangerousChars = { '#', '!', '"', '$', '&', '\'', '(', ')', '*', ';', '<', '=', '>', '?', '[', '\\', ']', '^', '`', '{', '|', '}', ' ', '\n', '\t', '~', '\r', '\f' };
         private static readonly string[] dangerousCommands = { "sleep", "shutdown", "reboot", "poweroff", "halt", "ifconfig", "chmod", "chown", "ping", "ssh", "scp", "curl", "wget", "telnet", "kill", "killall", "rm", "mv", "cp", "touch", "echo", "cat", "head", "tail", "grep", "find", "awk", "sed", "sort", "uniq", "wc", "ls", "env", "ps", "who", "whoami", "id", "w", "df", "du", "pwd", "uname", "hostname", "netstat", "passwd", "arch", "printenv", "logname", "pstree", "hostnamectl", "set", "lsattr", "killall5", "dmesg", "history", "free", "uptime", "finger", "top", "shopt", ":" };
         private static readonly char[] dangerousCharsInsideDoubleQuotes = { '$', '`', '\\', '!' };
 

--- a/Aikido.Zen.Test/ShellInjectionDetectorTests.cs
+++ b/Aikido.Zen.Test/ShellInjectionDetectorTests.cs
@@ -123,6 +123,40 @@ namespace Aikido.Zen.Test
             Assert.That(result, Is.True, "Should detect injection when start of string and separator is after user input.");
         }
 
+        [Test]
+        public void IsShellInjection_ShouldDetectCarriageReturnAsSeparator()
+        {
+            // Carriage return in user input is flagged
+            Assert.That(ShellInjectionDetector.IsShellInjection("ls \rrm", "\rrm"), Is.True);
+            Assert.That(ShellInjectionDetector.IsShellInjection("ls \rrm -rf", "\rrm -rf"), Is.True);
+
+            // Carriage return in user input when user input is the command
+            Assert.That(ShellInjectionDetector.IsShellInjection("sleep\r10", "sleep\r10"), Is.True);
+            Assert.That(ShellInjectionDetector.IsShellInjection("shutdown\r-h\rnow", "shutdown\r-h\rnow"), Is.True);
+
+            // Carriage return as separator between commands
+            Assert.That(ShellInjectionDetector.IsShellInjection("ls\rrm", "rm"), Is.True);
+            Assert.That(ShellInjectionDetector.IsShellInjection("echo test\rrm -rf /", "rm"), Is.True);
+            Assert.That(ShellInjectionDetector.IsShellInjection("rm\rls", "rm"), Is.True);
+        }
+
+        [Test]
+        public void IsShellInjection_ShouldDetectFormFeedAsSeparator()
+        {
+            // Form feed in user input is flagged
+            Assert.That(ShellInjectionDetector.IsShellInjection("ls \frm", "\frm"), Is.True);
+            Assert.That(ShellInjectionDetector.IsShellInjection("ls \frm -rf", "\frm -rf"), Is.True);
+
+            // Form feed in user input when user input is the command
+            Assert.That(ShellInjectionDetector.IsShellInjection("sleep\f10", "sleep\f10"), Is.True);
+            Assert.That(ShellInjectionDetector.IsShellInjection("shutdown\f-h\fnow", "shutdown\f-h\fnow"), Is.True);
+
+            // Form feed as separator between commands
+            Assert.That(ShellInjectionDetector.IsShellInjection("ls\frm", "rm"), Is.True);
+            Assert.That(ShellInjectionDetector.IsShellInjection("echo test\frm -rf /", "rm"), Is.True);
+            Assert.That(ShellInjectionDetector.IsShellInjection("rm\fls", "rm"), Is.True);
+        }
+
         public static IEnumerable<TestCaseData> GetTestData()
         {
             var jsonData = File.ReadAllText("testdata/data.ShellInjectionDetector.json");


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added carriage return and form feed as shell separators and dangerous characters


<sup>[More info](https://app.aikido.dev/featurebranch/scan/83039245?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->