### PR TITLE
Fix chunked request body scanning

### DIFF
--- a/Aikido.Zen.Benchmarks/HttpHelperBenchmarks.cs
+++ b/Aikido.Zen.Benchmarks/HttpHelperBenchmarks.cs
@@ -138,8 +138,7 @@ namespace Aikido.Zen.Benchmarks
                 _headers,
                 _cookies,
                 _jsonBody,
-                JsonContentType,
-                _jsonBody.Length
+                JsonContentType
             );
             _jsonBody.Position = 0;
         }
@@ -153,8 +152,7 @@ namespace Aikido.Zen.Benchmarks
                 _headers,
                 _cookies,
                 _xmlBody,
-                XmlContentType,
-                _xmlBody.Length
+                XmlContentType
             );
             _xmlBody.Position = 0;
         }
@@ -168,8 +166,7 @@ namespace Aikido.Zen.Benchmarks
                 _headers,
                 _cookies,
                 _formBody,
-                FormContentType,
-                _formBody.Length
+                FormContentType
             );
             _formBody.Position = 0;
         }
@@ -183,8 +180,7 @@ namespace Aikido.Zen.Benchmarks
                 _headers,
                 _cookies,
                 _multipartFormBody,
-                MultipartFormContentType,
-                _multipartFormBody.Length
+                MultipartFormContentType
             );
             _multipartFormBody.Position = 0;
         }

--- a/Aikido.Zen.Core/Helpers/HttpHelper.cs
+++ b/Aikido.Zen.Core/Helpers/HttpHelper.cs
@@ -74,7 +74,7 @@ namespace Aikido.Zen.Core.Helpers
             // Process Body
             try
             {
-                if (contentLength > 0)
+                if (body != null && body.CanRead)
                 {
                     parsedBody = await ProcessRequestBodyAsync(body, contentType, result);
                 }
@@ -177,7 +177,10 @@ namespace Aikido.Zen.Core.Helpers
             finally
             {
                 // reset the stream position
-                body.Seek(0, SeekOrigin.Begin);
+                if (body.CanSeek)
+                {
+                    body.Seek(0, SeekOrigin.Begin);
+                }
             }
 
             return parsedBody;

--- a/Aikido.Zen.Core/Helpers/HttpHelper.cs
+++ b/Aikido.Zen.Core/Helpers/HttpHelper.cs
@@ -45,7 +45,6 @@ namespace Aikido.Zen.Core.Helpers
         /// <param name="cookies">The cookies dictionary.</param>
         /// <param name="body">The request body stream.</param>
         /// <param name="contentType">The content type of the request.</param>
-        /// <param name="contentLength">The content length of the request body.</param>
         /// <returns>A HttpDataResult containing both flattened data and parsed body.</returns>
         public static async Task<HttpDataResult> ReadAndFlattenHttpDataAsync(
             IDictionary<string, string> routeParams,
@@ -53,8 +52,7 @@ namespace Aikido.Zen.Core.Helpers
             IDictionary<string, string> headers,
             IDictionary<string, string> cookies,
             Stream body,
-            string contentType,
-            long contentLength)
+            string contentType)
         {
             var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             object parsedBody = null;

--- a/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
@@ -74,8 +74,7 @@ namespace Aikido.Zen.DotNetCore.Middleware
                     headers: headersDictionary.ToDictionary(h => h.Key, h => string.Join(',', h.Value)),
                     cookies: context.Cookies,
                     body: request.Body,
-                    contentType: request.ContentType,
-                    contentLength: request.ContentLength ?? 0
+                    contentType: request.ContentType
                 );
 
                 // restore the original value of initialAllowSynchronousIOValue

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -107,8 +107,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                     headers: request.Headers.AllKeys.ToDictionary(k => k, k => request.Headers.Get(k)),
                     cookies: request.Cookies.AllKeys.ToDictionary(k => k, k => request.Cookies[k].Value),
                     body: request.InputStream,
-                    contentType: request.ContentType,
-                    contentLength: request.ContentLength
+                    contentType: request.ContentType
                 );
 
                 context.ParsedUserInput = httpData.FlattenedData;

--- a/Aikido.Zen.Test/ApiInfoHelperTests.cs
+++ b/Aikido.Zen.Test/ApiInfoHelperTests.cs
@@ -73,7 +73,7 @@ namespace Aikido.Zen.Test.Helpers
             var headerDict = headers ?? new Dictionary<string, string>();
             var routeParams = route ?? new Dictionary<string, string>();
 
-            var parsed = HttpHelper.ReadAndFlattenHttpDataAsync(routeParams, queryParams, headerDict, new Dictionary<string, string>(), bodyStream, contentType, bodyStream?.Length ?? 0).Result;
+            var parsed = HttpHelper.ReadAndFlattenHttpDataAsync(routeParams, queryParams, headerDict, new Dictionary<string, string>(), bodyStream, contentType).Result;
 
             return new Context
             {

--- a/Aikido.Zen.Test/HttpHelperTests.cs
+++ b/Aikido.Zen.Test/HttpHelperTests.cs
@@ -23,7 +23,7 @@ namespace Aikido.Zen.Test.Helpers
             using var bodyStream = new MemoryStream(Encoding.UTF8.GetBytes(body));
 
             // Act
-            var result = await HttpHelper.ReadAndFlattenHttpDataAsync(routeParams, queryParams, headers, cookies, bodyStream, contentType, bodyStream.Length);
+            var result = await HttpHelper.ReadAndFlattenHttpDataAsync(routeParams, queryParams, headers, cookies, bodyStream, contentType);
 
             // Assert
             Assert.That(result.FlattenedData, Is.Not.Null);
@@ -127,8 +127,7 @@ namespace Aikido.Zen.Test.Helpers
                 headers,
                 cookies,
                 bodyStream,
-                "application/json",
-                bodyStream.Length);
+                "application/json");
 
             // Assert
             Assert.That(result.FlattenedData["route.command"], Is.EqualTo("who%61mi"));
@@ -152,9 +151,8 @@ namespace Aikido.Zen.Test.Helpers
             Assert.That(result.FlattenedData.ContainsKey("body.literal|decoded"), Is.False);
         }
 
-        [TestCase(0L)]
-        [TestCase(-1L)]
-        public async Task ReadAndFlattenHttpDataAsync_ShouldProcessBodyWhenContentLengthIsMissing(long contentLength)
+        [Test]
+        public async Task ReadAndFlattenHttpDataAsync_ShouldProcessReadableBodyWithoutContentLengthHint()
         {
             const string body = "{\"userCommand\":\"whoami\"}";
             using var bodyStream = new MemoryStream(Encoding.UTF8.GetBytes(body));
@@ -165,8 +163,7 @@ namespace Aikido.Zen.Test.Helpers
                 new Dictionary<string, string>(),
                 new Dictionary<string, string>(),
                 bodyStream,
-                "application/json",
-                contentLength);
+                "application/json");
 
             Assert.That(result.FlattenedData["body.userCommand"], Is.EqualTo("whoami"));
             Assert.That(result.ParsedBody, Is.TypeOf<Dictionary<string, object>>());

--- a/Aikido.Zen.Test/HttpHelperTests.cs
+++ b/Aikido.Zen.Test/HttpHelperTests.cs
@@ -152,6 +152,30 @@ namespace Aikido.Zen.Test.Helpers
             Assert.That(result.FlattenedData.ContainsKey("body.literal|decoded"), Is.False);
         }
 
+        [TestCase(0L)]
+        [TestCase(-1L)]
+        public async Task ReadAndFlattenHttpDataAsync_ShouldProcessBodyWhenContentLengthIsMissing(long contentLength)
+        {
+            const string body = "{\"userCommand\":\"whoami\"}";
+            using var bodyStream = new MemoryStream(Encoding.UTF8.GetBytes(body));
+
+            var result = await HttpHelper.ReadAndFlattenHttpDataAsync(
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                bodyStream,
+                "application/json",
+                contentLength);
+
+            Assert.That(result.FlattenedData["body.userCommand"], Is.EqualTo("whoami"));
+            Assert.That(result.ParsedBody, Is.TypeOf<Dictionary<string, object>>());
+
+            var parsedBody = (Dictionary<string, object>)result.ParsedBody;
+            Assert.That(parsedBody["userCommand"]?.ToString(), Is.EqualTo("whoami"));
+            Assert.That(bodyStream.Position, Is.EqualTo(0));
+        }
+
         [Test]
         public void ToJsonObj_ShouldHandleTrueFalseNull()
         {


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed chunked request body scanning by checking stream readability and seekability

**🔧 Refactors**
* Removed unused contentLength parameter from HttpHelper and its callers


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101874408?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->