### PR TITLE
Increase default API timeout to 60 seconds

### DIFF
--- a/Aikido.Zen.Core/Api/ApiClientHttpClientFactory.cs
+++ b/Aikido.Zen.Core/Api/ApiClientHttpClientFactory.cs
@@ -7,7 +7,7 @@ namespace Aikido.Zen.Core.Api
 {
     internal static class ApiClientHttpClientFactory
     {
-        internal static HttpClient Create(int timeoutInMS = 30000)
+        internal static HttpClient Create(int timeoutInMS = 60000)
         {
             var handler = new HttpClientHandler
             {

--- a/Aikido.Zen.Test/ApiClientHttpClientFactoryTests.cs
+++ b/Aikido.Zen.Test/ApiClientHttpClientFactoryTests.cs
@@ -19,6 +19,14 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
+        public void Create_Uses60SecondDefaultTimeout()
+        {
+            using var httpClient = ApiClientHttpClientFactory.Create();
+
+            Assert.That(httpClient.Timeout, Is.EqualTo(TimeSpan.FromMilliseconds(60000)));
+        }
+
+        [Test]
         public void Create_SetsTimeout()
         {
             using var httpClient = ApiClientHttpClientFactory.Create(1234);


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Increased default HTTP client timeout from 30s to 60s.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106480429?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->