### PR TITLE
Fail fast on 32bit because no libzen_internals

### DIFF
--- a/Aikido.Zen.DotNetCore/DependencyInjection.cs
+++ b/Aikido.Zen.DotNetCore/DependencyInjection.cs
@@ -1,16 +1,11 @@
 using Aikido.Zen.Core;
 using Aikido.Zen.Core.Api;
-using Aikido.Zen.Core.Exceptions;
-using Aikido.Zen.Core.Helpers;
 using Aikido.Zen.DotNetCore.Middleware;
-using Aikido.Zen.DotNetCore.Patches;
-using Aikido.Zen.DotNetCore.RuntimeSca;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Aikido.Zen.DotNetCore
 {
@@ -83,9 +78,6 @@ namespace Aikido.Zen.DotNetCore
                 return services;
             }
 
-            // set zen version
-            AgentInfoHelper.SetVersion(typeof(Zen).Assembly.GetName().Version.ToString());
-
             // register basic logging
             services.AddLogging(builder => builder.AddConsole());
 
@@ -131,27 +123,7 @@ namespace Aikido.Zen.DotNetCore
 
             var contextAccessor = app.ApplicationServices.GetRequiredService<IHttpContextAccessor>();
             Zen.Initialize(app.ApplicationServices, contextAccessor);
-            var options = app.ApplicationServices.GetRequiredService<IOptions<AikidoOptions>>();
-
-            if (!string.IsNullOrEmpty(options?.Value?.AikidoToken))
-            {
-                var agent = Agent.NewInstance(app.ApplicationServices.GetRequiredService<IZenApi>());
-                var agentLogger = app.ApplicationServices.GetService<ILogger<Agent>>();
-                if (agentLogger != null)
-                {
-                    Agent.ConfigureLogger(agentLogger);
-                }
-                agent.Start();
-
-                var exceptionLogger = app.ApplicationServices.GetService<ILogger<AikidoException>>();
-                if (exceptionLogger != null)
-                {
-                    AikidoException.ConfigureLogger(exceptionLogger);
-                }
-                EnvironmentHelper.ReportValues();
-                RuntimeAssemblyTracker.Instance.SubscribeToAppDomain(AppDomain.CurrentDomain);
-            }
-            Patcher.Patch();
+            Zen.Start();
             app.UseMiddleware<ContextMiddleware>();
             app.UseMiddleware<BlockingMiddleware>();
             return app;

--- a/Aikido.Zen.DotNetCore/Zen.cs
+++ b/Aikido.Zen.DotNetCore/Zen.cs
@@ -27,6 +27,7 @@ namespace Aikido.Zen.DotNetCore
 
         public static void Start()
         {
+            // libzen_internals only available on 64
             if (!Environment.Is64BitProcess)
             {
                 throw new PlatformNotSupportedException(

--- a/Aikido.Zen.DotNetCore/Zen.cs
+++ b/Aikido.Zen.DotNetCore/Zen.cs
@@ -1,6 +1,15 @@
 using Aikido.Zen.Core;
+using Aikido.Zen.Core.Api;
+using Aikido.Zen.Core.Exceptions;
+using Aikido.Zen.Core.Helpers;
 using Aikido.Zen.Core.Models;
+using Aikido.Zen.DotNetCore.Patches;
+using Aikido.Zen.DotNetCore.RuntimeSca;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Runtime.InteropServices;
 
 namespace Aikido.Zen.DotNetCore
 {
@@ -14,6 +23,46 @@ namespace Aikido.Zen.DotNetCore
         {
             _serviceProvider = serviceProvider;
             _httpContextAccessor = httpContextAccessor;
+        }
+
+        public static void Start()
+        {
+            if (!Environment.Is64BitProcess)
+            {
+                throw new PlatformNotSupportedException(
+                    $"Aikido Zen does not support 32-bit processes. Detected process architecture: {RuntimeInformation.ProcessArchitecture}");
+            }
+
+            if (_serviceProvider == null || _httpContextAccessor == null)
+            {
+                throw new InvalidOperationException("Aikido.Zen.DotNetCore.Zen.Initialize must be called before Zen.Start().");
+            }
+
+            AgentInfoHelper.SetVersion(typeof(Zen).Assembly.GetName().Version.ToString());
+            var options = _serviceProvider.GetRequiredService<IOptions<AikidoOptions>>();
+
+            if (!string.IsNullOrEmpty(options?.Value?.AikidoToken))
+            {
+                var agent = Agent.NewInstance(_serviceProvider.GetRequiredService<IZenApi>());
+                var agentLogger = _serviceProvider.GetService<ILogger<Agent>>();
+                if (agentLogger != null)
+                {
+                    Agent.ConfigureLogger(agentLogger);
+                }
+
+                agent.Start();
+
+                var exceptionLogger = _serviceProvider.GetService<ILogger<AikidoException>>();
+                if (exceptionLogger != null)
+                {
+                    AikidoException.ConfigureLogger(exceptionLogger);
+                }
+
+                EnvironmentHelper.ReportValues();
+                RuntimeAssemblyTracker.Instance.SubscribeToAppDomain(AppDomain.CurrentDomain);
+            }
+
+            Patcher.Patch();
         }
 
         public static void SetUser(string id, string name, HttpContext context)

--- a/Aikido.Zen.DotNetFramework/Zen.cs
+++ b/Aikido.Zen.DotNetFramework/Zen.cs
@@ -18,17 +18,17 @@ namespace Aikido.Zen.DotNetFramework
         private static HarmonyLib.Harmony harmony = new HarmonyLib.Harmony("reference");
         public static void Start()
         {
+            if (!Environment.Is64BitProcess)
+            {
+                throw new PlatformNotSupportedException(
+                    $"Aikido Zen does not support 32-bit processes. Detected process architecture: {RuntimeInformation.ProcessArchitecture}");
+            }
+
             // initialize the options, this will ensure the environment variables are set
             AikidoConfiguration.Init();
             if (Environment.GetEnvironmentVariable("AIKIDO_DISABLE") == "true")
             {
                 return;
-            }
-
-            if (!Environment.Is64BitProcess)
-            {
-                throw new PlatformNotSupportedException(
-                    $"Aikido Zen does not support 32-bit processes. Detected process architecture: {RuntimeInformation.ProcessArchitecture}");
             }
 
             // set zen version

--- a/Aikido.Zen.DotNetFramework/Zen.cs
+++ b/Aikido.Zen.DotNetFramework/Zen.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Web;
 using Aikido.Zen.Core;
 using Aikido.Zen.Core.Api;
@@ -23,6 +24,13 @@ namespace Aikido.Zen.DotNetFramework
             {
                 return;
             }
+
+            if (!Environment.Is64BitProcess)
+            {
+                throw new PlatformNotSupportedException(
+                    $"Aikido Zen does not support 32-bit processes. Detected process architecture: {RuntimeInformation.ProcessArchitecture}");
+            }
+
             // set zen version
             AgentInfoHelper.SetVersion(typeof(Zen).Assembly.GetName().Version.ToString());
             // patch the sinks

--- a/Aikido.Zen.DotNetFramework/Zen.cs
+++ b/Aikido.Zen.DotNetFramework/Zen.cs
@@ -18,6 +18,7 @@ namespace Aikido.Zen.DotNetFramework
         private static HarmonyLib.Harmony harmony = new HarmonyLib.Harmony("reference");
         public static void Start()
         {
+            // libzen_internals only available on 64
             if (!Environment.Is64BitProcess)
             {
                 throw new PlatformNotSupportedException(

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Zen only works in 64-bit processes.
 
 ## Installation
 
-Zen requires a 64-bit process because `libzen_internals` is only available for 64-bit runtimes. 32-bit startup is not supported.
 
 ### .NET Core
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Zen operates autonomously on the same server as your .NET app to:
 
 ## Supported libraries and frameworks
 
+Zen only works in 64-bit processes.
+
 ### Web frameworks
 * ✅ ASP.NET Core 6.0
 * ✅ ASP.NET Core 7.0
@@ -64,6 +66,8 @@ Zen operates autonomously on the same server as your .NET app to:
 * ✅ EF Core
 
 ## Installation
+
+Zen requires a 64-bit process because `libzen_internals` is only available for 64-bit runtimes. 32-bit startup is not supported.
 
 ### .NET Core
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added fail-fast 32-bit process guard during startup, throwing PlatformNotSupportedException.

**🔧 Refactors**
* Moved agent initialization, logging, and patching into Zen.Start to centralize startup behavior.
* Removed inline startup code from DependencyInjection and simplified startup call.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106980323?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->