### PR TITLE
Fix netfx query flattening for unnamed values

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -125,4 +125,4 @@ jobs:
           sleep_before_test: 15
           max_parallel_tests: 5
           test_timeout: 900
-          skip_tests: test_rate_limiting_group_id_1_minute,test_stored_ssrf_no_context,test_path_traversal,test_bypassed_ip,test_stored_ssrf,test_ssrf,test_ssrf_diffrent_port,test_user_rate_limiting_1_minute,test_outbound_domain_blocking,test_user_rate_limiting_1_minute_without_x_forwarded_for
+          skip_tests: test_rate_limiting_group_id_1_minute,test_stored_ssrf_no_context,test_path_traversal,test_bypassed_ip,test_stored_ssrf,test_ssrf,test_ssrf_diffrent_port,test_outbound_domain_blocking,test_user_rate_limiting_1_minute_without_x_forwarded_for

--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -125,4 +125,4 @@ jobs:
           sleep_before_test: 15
           max_parallel_tests: 5
           test_timeout: 900
-          skip_tests: test_rate_limiting_group_id_1_minute,test_stored_ssrf_no_context,test_path_traversal,test_bypassed_ip,test_stored_ssrf,test_ssrf,test_ssrf_diffrent_port,test_outbound_domain_blocking,test_user_rate_limiting_1_minute_without_x_forwarded_for
+          skip_tests: test_rate_limiting_group_id_1_minute,test_stored_ssrf_no_context,test_path_traversal,test_bypassed_ip,test_stored_ssrf,test_ssrf,test_ssrf_diffrent_port,test_outbound_domain_blocking

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -191,17 +191,19 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
 
             foreach (string key in queryString.AllKeys)
             {
+                // Unnamed query values like ?#fragment may come with null keys
+                // Replace with empty string to avoid exceptions
+                var safeKey = key ?? string.Empty;
                 var values = queryString.GetValues(key);
+                
                 // Example: for ?foo=a&foo=b, the dictionary will be:
                 // { "foo": "a", "foo[1]": "b" }
                 // The first value ("a") is used as the default ("foo"), matching ASP.NET Core's default behavior for query and header collections.
-                // ASP.NET Framework can return a null key for unnamed query values like ?#fragment, so store it under an empty key.
                 for (int i = 0; i < values.Length; i++)
                 {
-                    string dictKey = i == 0 ? key ?? string.Empty : $"{key}[{i}]";
+                    string dictKey = i == 0 ? safeKey : $"{safeKey}[{i}]";
                     result[dictKey] = values[i];
                 }
-
             }
 
             return result;

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -195,9 +195,10 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                 // Example: for ?foo=a&foo=b, the dictionary will be:
                 // { "foo": "a", "foo[1]": "b" }
                 // The first value ("a") is used as the default ("foo"), matching ASP.NET Core's default behavior for query and header collections.
+                // ASP.NET Framework can return a null key for unnamed query values like ?#fragment, so store it under an empty key.
                 for (int i = 0; i < values.Length; i++)
                 {
-                    string dictKey = i == 0 ? key : $"{key}[{i}]";
+                    string dictKey = i == 0 ? key ?? string.Empty : $"{key}[{i}]";
                     result[dictKey] = values[i];
                 }
 

--- a/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
+++ b/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
@@ -199,6 +199,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
             // Arrange
             var queryString = new System.Collections.Specialized.NameValueCollection();
             queryString.Add("param1", "value1");
+            queryString.Add(null, "#fragment");
 
             // Act
             var method = typeof(ContextModule).GetMethod("FlattenQueryParameters", BindingFlags.NonPublic | BindingFlags.Static);
@@ -208,6 +209,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
             Assert.That(result, Is.Not.Null);
             Assert.That(result.ContainsKey("param1"), Is.True);
             Assert.That(result["param1"], Is.EqualTo("value1"));
+            Assert.That(result[string.Empty], Is.EqualTo("#fragment"));
         }
 
         [Test]


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated QA workflow to reduce skipped tests for NetFX job.

**🐛 Bugfixes**
* Fixed NetFX query flattening to handle null and unnamed keys.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109467830?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->