### PR TITLE
Fix bypassed ip and rate limited agent stats on net core and net framework

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -75,7 +75,7 @@ jobs:
           dockerfile_path: ./zen-demo-dotnet-core/Dockerfile
           app_port: 8080
           sleep_before_test: 10
-          skip_tests: test_rate_limiting_group_id_1_minute,test_stored_ssrf_no_context,test_path_traversal,test_bypassed_ip,test_stored_ssrf,test_ssrf
+          skip_tests: test_rate_limiting_group_id_1_minute,test_stored_ssrf_no_context,test_path_traversal,test_stored_ssrf,test_ssrf
 
   qa-tests-netfx:
     needs: build-package

--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -125,4 +125,4 @@ jobs:
           sleep_before_test: 15
           max_parallel_tests: 5
           test_timeout: 900
-          skip_tests: test_rate_limiting_group_id_1_minute,test_stored_ssrf_no_context,test_path_traversal,test_bypassed_ip,test_stored_ssrf,test_ssrf,test_ssrf_diffrent_port,test_user_rate_limiting_1_minute,test_outbound_domain_blocking,test_user_rate_limiting_1_minute_without_x_forwarded_for
+          skip_tests: test_rate_limiting_group_id_1_minute,test_stored_ssrf_no_context,test_path_traversal,test_stored_ssrf,test_ssrf,test_ssrf_diffrent_port,test_user_rate_limiting_1_minute,test_outbound_domain_blocking,test_user_rate_limiting_1_minute_without_x_forwarded_for

--- a/Aikido.Zen.Core/Models/AgentContext.cs
+++ b/Aikido.Zen.Core/Models/AgentContext.cs
@@ -38,6 +38,11 @@ namespace Aikido.Zen.Core.Models
             _stats.OnAbortedRequest();
         }
 
+        public void AddRateLimitedRequest()
+        {
+            _stats.OnRateLimitedRequest();
+        }
+
         public void AddAttackDetected(bool blocked = false)
         {
             _stats.OnDetectedAttack(blocked);
@@ -320,6 +325,7 @@ namespace Aikido.Zen.Core.Models
         public IEnumerable<EndpointConfig> Endpoints => _config.Endpoints;
         public int Requests => _stats.Requests.Total;
         public int RequestsAborted => _stats.Requests.Aborted;
+        public int RequestsRateLimited => _stats.Requests.RateLimited;
         public int AttacksDetected => _stats.Requests.AttacksDetected.Total;
         public int AttacksBlocked => _stats.Requests.AttacksDetected.Blocked;
         public int AttackWavesDetected => _stats.Requests.AttackWaves.Total;

--- a/Aikido.Zen.Core/Models/AgentStats.cs
+++ b/Aikido.Zen.Core/Models/AgentStats.cs
@@ -105,6 +105,7 @@ namespace Aikido.Zen.Core.Models
             {
                 Total = 0,
                 Aborted = 0,
+                RateLimited = 0,
                 AttacksDetected = new AttacksDetected
                 {
                     Total = 0,
@@ -182,6 +183,14 @@ namespace Aikido.Zen.Core.Models
         public void OnAbortedRequest()
         {
             Interlocked.Increment(ref _requests.Aborted);
+        }
+
+        /// <summary>
+        /// Records that a request was rate limited.
+        /// </summary>
+        public void OnRateLimitedRequest()
+        {
+            Interlocked.Increment(ref _requests.RateLimited);
         }
 
         /// <summary>

--- a/Aikido.Zen.Core/Models/Events/Heartbeat.cs
+++ b/Aikido.Zen.Core/Models/Events/Heartbeat.cs
@@ -65,6 +65,7 @@ namespace Aikido.Zen.Core.Models.Events
             heartbeat.Stats.CopyIpAddressBreakdown(context.Stats.IpAddresses.Breakdown);
             heartbeat.Stats.Requests.Total = context.Requests;
             heartbeat.Stats.Requests.Aborted = context.RequestsAborted;
+            heartbeat.Stats.Requests.RateLimited = context.RequestsRateLimited;
             heartbeat.Stats.Requests.AttacksDetected = new AttacksDetected
             {
                 Blocked = context.AttacksBlocked,

--- a/Aikido.Zen.Core/Models/Ip/Blocklist.cs
+++ b/Aikido.Zen.Core/Models/Ip/Blocklist.cs
@@ -251,20 +251,7 @@ namespace Aikido.Zen.Core.Models.Ip
 
                 if (_bypassedIps.HasItems)
                 {
-                    if (IPAddress.TryParse(ip, out var parsedIp))
-                    {
-                        // Check the IP as provided, including normal IPv4 or IPv6 ranges.
-                        if (_bypassedIps.IsIpInRange(parsedIp.ToString()))
-                        {
-                            return true;
-                        }
-
-                        // Also match IPv4-mapped IPv6 requests against IPv4 bypass ranges.
-                        if (parsedIp.IsIPv4MappedToIPv6)
-                        {
-                            return _bypassedIps.IsIpInRange(parsedIp.MapToIPv4().ToString());
-                        }
-                    }
+                    return _bypassedIps.IsIpInRange(ip);
                 }
 
                 return false;

--- a/Aikido.Zen.Core/Models/Ip/Blocklist.cs
+++ b/Aikido.Zen.Core/Models/Ip/Blocklist.cs
@@ -251,7 +251,20 @@ namespace Aikido.Zen.Core.Models.Ip
 
                 if (_bypassedIps.HasItems)
                 {
-                    return _bypassedIps.IsIpInRange(ip);
+                    if (IPAddress.TryParse(ip, out var parsedIp))
+                    {
+                        // Check the IP as provided, including normal IPv4 or IPv6 ranges.
+                        if (_bypassedIps.IsIpInRange(parsedIp.ToString()))
+                        {
+                            return true;
+                        }
+
+                        // Also match IPv4-mapped IPv6 requests against IPv4 bypass ranges.
+                        if (parsedIp.IsIPv4MappedToIPv6)
+                        {
+                            return _bypassedIps.IsIpInRange(parsedIp.MapToIPv4().ToString());
+                        }
+                    }
                 }
 
                 return false;

--- a/Aikido.Zen.Core/Models/Ip/IPRange.cs
+++ b/Aikido.Zen.Core/Models/Ip/IPRange.cs
@@ -105,34 +105,49 @@ class IPRange
                 return false;
             }
 
-            bool isIPv6 = ipAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6;
-            var currentNode = isIPv6 ? _ipv6Root : _ipv4Root;
-            var addressBytes = ipAddress.GetAddressBytes();
-
-            foreach (var byteValue in addressBytes)
+            if (IsIpInRange(ipAddress))
             {
-                for (int bitIndex = 7; bitIndex >= 0; bitIndex--)
-                {
-                    if (currentNode.IsTerminal)
-                    {
-                        return true;
-                    }
-
-                    int bit = (byteValue >> bitIndex) & 1;
-                    if (currentNode.Children[bit] == null)
-                    {
-                        return false;
-                    }
-
-                    currentNode = currentNode.Children[bit];
-                }
+                return true;
             }
 
-            return currentNode.IsTerminal;
+            if (ipAddress.IsIPv4MappedToIPv6)
+            {
+                return IsIpInRange(ipAddress.MapToIPv4());
+            }
+
+            return false;
         }
         finally
         {
             _lock.ExitReadLock();
         }
+    }
+
+    private bool IsIpInRange(IPAddress ipAddress)
+    {
+        bool isIPv6 = ipAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6;
+        var currentNode = isIPv6 ? _ipv6Root : _ipv4Root;
+        var addressBytes = ipAddress.GetAddressBytes();
+
+        foreach (var byteValue in addressBytes)
+        {
+            for (int bitIndex = 7; bitIndex >= 0; bitIndex--)
+            {
+                if (currentNode.IsTerminal)
+                {
+                    return true;
+                }
+
+                int bit = (byteValue >> bitIndex) & 1;
+                if (currentNode.Children[bit] == null)
+                {
+                    return false;
+                }
+
+                currentNode = currentNode.Children[bit];
+            }
+        }
+
+        return currentNode.IsTerminal;
     }
 }

--- a/Aikido.Zen.Core/Models/Requests.cs
+++ b/Aikido.Zen.Core/Models/Requests.cs
@@ -4,6 +4,7 @@ namespace Aikido.Zen.Core.Models
     {
         public int Total; // must be a field to be thread safe
         public int Aborted; // must be a field to be thread safe
+        public int RateLimited; // must be a field to be thread safe
         public AttacksDetected AttacksDetected { get; set; }
         public AttacksDetected AttackWaves { get; set; }
     }

--- a/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
@@ -63,6 +63,7 @@ namespace Aikido.Zen.DotNetCore.Middleware
                 if (!isAllowed)
                 {
                     Agent.Instance.Context.AddAbortedRequest();
+                    Agent.Instance.Context.AddRateLimitedRequest();
                     context.Response.StatusCode = 429;
 
                     if (effectiveConfig != null)

--- a/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
@@ -62,7 +62,6 @@ namespace Aikido.Zen.DotNetCore.Middleware
 
                 if (!isAllowed)
                 {
-                    Agent.Instance.Context.AddAbortedRequest();
                     Agent.Instance.Context.AddRateLimitedRequest();
                     context.Response.StatusCode = 429;
 

--- a/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
@@ -26,19 +26,13 @@ namespace Aikido.Zen.DotNetCore.Middleware
 
         public async Task InvokeAsync(HttpContext httpContext, RequestDelegate next)
         {
-            try
+            if (EnvironmentHelper.IsDisabled)
             {
-                if (EnvironmentHelper.IsDisabled)
-                {
-                    // call the next middleware
-                    await next(httpContext);
-                    return;
-                }
+                // call the next middleware
+                await next(httpContext);
+                return;
             }
-            catch (Exception ex)
-            {
-                LogHelper.ErrorLog(Agent.Logger, $"Error while checking if the ip is bypassed: {ex.Message}");
-            }
+
             if (!TryPrepareContext(httpContext, out var queryDictionary, out var headersDictionary, out var context))
             {
                 // if preparing the context failed, we can't capture the request, so we just call the next middleware

--- a/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
@@ -43,7 +43,16 @@ namespace Aikido.Zen.DotNetCore.Middleware
             {
                 // if preparing the context failed, we can't capture the request, so we just call the next middleware
                 await next(httpContext);
+                return;
             }
+
+            if (Agent.Instance.Context.BlockList.IsIPBypassed(context.RemoteAddress))
+            {
+                // Bypassed IPs skip all Zen handling, including API discovery and request stats.
+                await next(httpContext);
+                return;
+            }
+
             try
             {
                 LogHelper.DebugLog(Agent.Logger, "Capturing request context");

--- a/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
@@ -77,7 +77,6 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
 
                 if (!isAllowed)
                 {
-                    Agent.Instance.Context.AddAbortedRequest();
                     Agent.Instance.Context.AddRateLimitedRequest();
                     CompleteRequestWithResponse(
                         httpContext,

--- a/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
@@ -78,6 +78,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                 if (!isAllowed)
                 {
                     Agent.Instance.Context.AddAbortedRequest();
+                    Agent.Instance.Context.AddRateLimitedRequest();
                     CompleteRequestWithResponse(
                         httpContext,
                         429,

--- a/Aikido.Zen.Test/AgentConfigurationTests.cs
+++ b/Aikido.Zen.Test/AgentConfigurationTests.cs
@@ -299,6 +299,7 @@ namespace Aikido.Zen.Test
 
             // Assert
             Assert.That(_config.GetMatchingMonitoredIPListKeys("9.9.9.9"), Is.EquivalentTo(new[] { "tor/exit_nodes" }));
+            Assert.That(_config.GetMatchingMonitoredIPListKeys("::ffff:9.9.9.9"), Is.EquivalentTo(new[] { "tor/exit_nodes" }));
             Assert.That(_config.IsMonitoredUserAgent("GoogleBot/2.1"), Is.True);
             Assert.That(_config.GetMatchingUserAgentKeys("GoogleBot/2.1"), Is.EquivalentTo(new[] { "googlebot" }));
         }
@@ -322,6 +323,7 @@ namespace Aikido.Zen.Test
 
             // Assert
             Assert.That(_config.GetMatchingBlockedIPListKeys("8.8.8.8"), Is.EquivalentTo(new[] { "known_threat_actors/public_scanners" }));
+            Assert.That(_config.GetMatchingBlockedIPListKeys("::ffff:8.8.8.8"), Is.EquivalentTo(new[] { "known_threat_actors/public_scanners" }));
         }
 
         [Test]

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -616,6 +616,7 @@ namespace Aikido.Zen.Test
             _agent.Context.AddUser(context.User, context.RemoteAddress);
             _agent.Context.AddRoute(context);
             _agent.Context.AddRequest();
+            _agent.Context.AddRateLimitedRequest();
             _agent.Context.AddAttackDetected(true);
             _agent.Context.IsBlocked(context, out _);
             _agent.SetContextMiddlewareInstalled(true);
@@ -630,6 +631,7 @@ namespace Aikido.Zen.Test
                 Assert.That(heartbeat.Users.Count, Is.EqualTo(1));
                 Assert.That(heartbeat.Routes.FirstOrDefault()?.Path ?? "", Is.EqualTo("/test"));
                 Assert.That(heartbeat.Stats.Requests.Total, Is.EqualTo(1));
+                Assert.That(heartbeat.Stats.Requests.RateLimited, Is.EqualTo(1));
                 Assert.That(heartbeat.Stats.Requests.AttacksDetected.Blocked, Is.EqualTo(1));
                 Assert.That(heartbeat.Stats.Requests.AttacksDetected.Total, Is.EqualTo(1));
                 Assert.That(heartbeat.Stats.StartedAt, Is.GreaterThan(0));

--- a/Aikido.Zen.Test/BlockListTests.cs
+++ b/Aikido.Zen.Test/BlockListTests.cs
@@ -282,6 +282,16 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
+        public void BypassedIPs_ShouldMatchIPv4MappedIPv6AgainstIPv4Cidr()
+        {
+            // Arrange
+            _blockList.UpdateBypassedIps(new[] { "23.45.67.89/24" });
+
+            // Act & Assert
+            Assert.That(_blockList.IsIPBypassed("::ffff:23.45.67.89"), Is.True);
+        }
+
+        [Test]
         public void PrivateIPs_ShouldAlwaysBeAllowed()
         {
             // Arrange

--- a/Aikido.Zen.Test/BlockListTests.cs
+++ b/Aikido.Zen.Test/BlockListTests.cs
@@ -292,6 +292,51 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
+        public void IPv4MappedIPv6_ShouldMatchIPv4RangesAcrossIpRules()
+        {
+            // Arrange
+            _blockList.UpdateBlockedIps(new[] { ("blocked", (IEnumerable<string>)new[] { "23.45.67.0/24" }) });
+            _blockList.UpdateAllowedIps(new[] { "23.45.67.0/24" });
+            _blockList.UpdateBypassedIps(new[] { "23.45.67.0/24" });
+            _blockList.UpdateAllowedIpsPerEndpoint(new[]
+            {
+                new EndpointConfig
+                {
+                    Method = "GET",
+                    Route = "testUrl",
+                    AllowedIPAddresses = new[] { "23.45.67.0/24" }
+                }
+            });
+
+            var allowedContext = new Context
+            {
+                RemoteAddress = "::ffff:23.45.67.89",
+                Method = "GET",
+                Url = "http://localhost:80/testUrl",
+                Route = "testUrl"
+            };
+            var deniedContext = new Context
+            {
+                RemoteAddress = "::ffff:23.45.68.89",
+                Method = "GET",
+                Url = "http://localhost:80/testUrl",
+                Route = "testUrl"
+            };
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(_blockList.IsIPBlocked("::ffff:23.45.67.89"), Is.True);
+                Assert.That(_blockList.GetMatchingBlockedIPListKeys("::ffff:23.45.67.89"), Is.EquivalentTo(new[] { "blocked" }));
+                Assert.That(_blockList.IsIPAllowed("::ffff:23.45.67.89"), Is.True);
+                Assert.That(_blockList.IsIPAllowed("::ffff:23.45.68.89"), Is.False);
+                Assert.That(_blockList.IsIPBypassed("::ffff:23.45.67.89"), Is.True);
+                Assert.That(_blockList.IsIpAllowedForEndpoint(allowedContext), Is.True);
+                Assert.That(_blockList.IsIpAllowedForEndpoint(deniedContext), Is.False);
+            });
+        }
+
+        [Test]
         public void PrivateIPs_ShouldAlwaysBeAllowed()
         {
             // Arrange

--- a/Aikido.Zen.Test/StatsTests.cs
+++ b/Aikido.Zen.Test/StatsTests.cs
@@ -66,6 +66,7 @@ namespace Aikido.Zen.Test
             Assert.That(stats.Operations, Is.Empty, "Operations dictionary should be empty after reset.");
             Assert.That(stats.Requests.Total, Is.EqualTo(0), "Requests total should be 0 after reset.");
             Assert.That(stats.Requests.Aborted, Is.EqualTo(0), "Requests aborted should be 0 after reset.");
+            Assert.That(stats.Requests.RateLimited, Is.EqualTo(0), "Requests rate limited should be 0 after reset.");
             Assert.That(stats.Requests.AttacksDetected.Total, Is.EqualTo(0), "Requests attacks total should be 0 after reset.");
             Assert.That(stats.Requests.AttacksDetected.Blocked, Is.EqualTo(0), "Requests attacks blocked should be 0 after reset.");
             Assert.That(newStartedAt, Is.GreaterThan(initialStartedAt), "StartedAt should be updated after reset.");
@@ -93,6 +94,14 @@ namespace Aikido.Zen.Test
             stats.OnRequest(); // Make non-empty
             Assert.That(stats.IsEmpty(), Is.False);
 
+        }
+
+        [Test]
+        public void OnRateLimitedRequest_IncrementsRequestsRateLimited()
+        {
+            var stats = new AgentStats();
+            stats.OnRateLimitedRequest();
+            Assert.That(stats.Requests.RateLimited, Is.EqualTo(1));
         }
 
         [Test]

--- a/Aikido.Zen.Tests.DotNetCore/ContextMiddlewareTests.cs
+++ b/Aikido.Zen.Tests.DotNetCore/ContextMiddlewareTests.cs
@@ -68,6 +68,53 @@ namespace Aikido.Zen.Tests.DotNetCore
         }
 
         [Test]
+        public async Task InvokeAsync_BypassedIp_CallsNextWithoutCapturingContextOrStats()
+        {
+            var originalDisable = Environment.GetEnvironmentVariable("AIKIDO_DISABLE");
+            const string bypassedIp = "93.184.216.34";
+            var context = new DefaultHttpContext();
+            context.Request.Scheme = "http";
+            context.Request.Host = new HostString("test.local");
+            context.Request.Path = "/api/create";
+            context.Request.Method = "POST";
+            context.Request.ContentType = "application/json";
+            context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("""{"name":"test"}"""));
+            context.Connection.RemoteIpAddress = IPAddress.Parse(bypassedIp);
+
+            var nextCalled = false;
+            RequestDelegate next = httpContext =>
+            {
+                nextCalled = true;
+                httpContext.Response.StatusCode = StatusCodes.Status200OK;
+                return Task.CompletedTask;
+            };
+
+            try
+            {
+                Environment.SetEnvironmentVariable("AIKIDO_DISABLE", "false");
+                Agent.Instance.Context.Config.Clear();
+                Agent.Instance.ClearContext();
+                Agent.Instance.Context.BlockList.UpdateBypassedIps(new[] { bypassedIp });
+
+                await _contextMiddleware.InvokeAsync(context, next);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(nextCalled, Is.True);
+                    Assert.That(context.Items.ContainsKey("Aikido.Zen.Context"), Is.False);
+                    Assert.That(Agent.Instance.Context.Requests, Is.EqualTo(0));
+                    Assert.That(Agent.Instance.Context.Routes, Is.Empty);
+                });
+            }
+            finally
+            {
+                Agent.Instance.ClearContext();
+                Agent.Instance.Context.Config.Clear();
+                Environment.SetEnvironmentVariable("AIKIDO_DISABLE", originalDisable);
+            }
+        }
+
+        [Test]
         public void GetParametrizedRoute_ReturnsCorrectRoutePattern()
         {
             // Arrange


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added rate-limited request counting and heartbeat reporting fields.
* Skipped netcore request capture for bypassed IPs to avoid processing.
* Enabled bypassed IP QA tests for netcore and netfx workflows.

**🐛 Bugfixes**
* Replaced aborted request increment with rate-limited increment when limiting.
* Handled IPv4-mapped IPv6 addresses when checking IP ranges correctly.

**🔧 Refactors**
* Cleaned up ContextMiddleware control flow and improved error handling.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109478787?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->