### PR TITLE
Fix path traversal QA coverage

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -75,7 +75,7 @@ jobs:
           dockerfile_path: ./zen-demo-dotnet-core/Dockerfile
           app_port: 8080
           sleep_before_test: 10
-          skip_tests: test_stored_ssrf_no_context,test_path_traversal,test_stored_ssrf,test_ssrf
+          skip_tests: test_stored_ssrf_no_context,test_stored_ssrf,test_ssrf
 
   qa-tests-netfx:
     needs: build-package
@@ -125,4 +125,4 @@ jobs:
           sleep_before_test: 15
           max_parallel_tests: 5
           test_timeout: 900
-          skip_tests: test_stored_ssrf_no_context,test_path_traversal,test_stored_ssrf,test_ssrf,test_ssrf_diffrent_port,test_outbound_domain_blocking
+          skip_tests: test_stored_ssrf_no_context,test_stored_ssrf,test_ssrf,test_ssrf_diffrent_port,test_outbound_domain_blocking

--- a/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
@@ -23,36 +23,36 @@ namespace Aikido.Zen.Core.Vulnerabilities
         private static readonly string[] DangerousPathStarts = new[]
         {
             // Linux specific
-            "/bin/",
-            "/boot/",
-            "/dev/",
-            "/etc/",
-            "/home/",
-            "/init/",
-            "/lib/",
-            "/media/",
-            "/mnt/",
-            "/opt/",
-            "/proc/",
-            "/root/",
-            "/run/",
-            "/sbin/",
-            "/srv/",
-            "/sys/",
-            "/tmp/",
-            "/usr/",
-            "/var/",
+            "bin/",
+            "boot/",
+            "dev/",
+            "etc/",
+            "home/",
+            "init/",
+            "lib/",
+            "media/",
+            "mnt/",
+            "opt/",
+            "proc/",
+            "root/",
+            "run/",
+            "sbin/",
+            "srv/",
+            "sys/",
+            "tmp/",
+            "usr/",
+            "var/",
             // Common container/cloud directories
-            "/app/",
-            "/code/",
+            "app/",
+            "code/",
             // macOS specific
-            "/applications/",
-            "/cores/",
-            "/library/",
-            "/private/",
-            "/users/",
-            "/system/",
-            "/volumes/",
+            "applications/",
+            "cores/",
+            "library/",
+            "private/",
+            "users/",
+            "system/",
+            "volumes/",
             // Windows specific
             "c:/",
             "c:\\",
@@ -116,9 +116,8 @@ namespace Aikido.Zen.Core.Vulnerabilities
                 // If URL decode fails, check the raw input
             }
 
-            // Convert to lowercase for case-insensitive matching
-            ReadOnlySpan<char> inputSpan = input.ToLowerInvariant().AsSpan();
-            ReadOnlySpan<char> pathSpan = path.ToLowerInvariant().AsSpan();
+            ReadOnlySpan<char> inputSpan = input.AsSpan();
+            ReadOnlySpan<char> pathSpan = path.AsSpan();
 
 
             bool inputHasUnsafeParts = ContainsUnsafePathParts(inputSpan);
@@ -128,8 +127,8 @@ namespace Aikido.Zen.Core.Vulnerabilities
 
             if (checkPathStart)
             {
-                ReadOnlySpan<char> normalizedInputSpan = SkipPathStartNoise(inputSpan);
-                ReadOnlySpan<char> normalizedPathSpan = SkipPathStartNoise(pathSpan);
+                ReadOnlySpan<char> normalizedInputSpan = inputSpan.TrimStart("/\\.?".AsSpan());
+                ReadOnlySpan<char> normalizedPathSpan = pathSpan.TrimStart("/\\.?".AsSpan());
 
                 // Check for absolute path traversal
                 foreach (var start in DangerousPathStarts)
@@ -158,29 +157,5 @@ namespace Aikido.Zen.Core.Vulnerabilities
             return false;
         }
 
-        private static ReadOnlySpan<char> SkipPathStartNoise(ReadOnlySpan<char> path)
-        {
-            // //./etc/passwd -> /etc/passwd
-            // /././etc/passwd -> /etc/passwd
-
-            var i = 1; // start from second char
-
-            while (i < path.Length)
-            {
-                if (path[i] == '/' ||
-                    path[i] == '\\' ||
-                    path[i] == '.')
-                {
-                    i++;
-                }
-                else
-                {
-                    break;
-                }
-            }
-
-            // Slice one char behind so we do not trim the real prefix.
-            return path.Slice(i - 1);
-        }
     }
 }

--- a/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
@@ -23,36 +23,36 @@ namespace Aikido.Zen.Core.Vulnerabilities
         private static readonly string[] DangerousPathStarts = new[]
         {
             // Linux specific
-            "bin/",
-            "boot/",
-            "dev/",
-            "etc/",
-            "home/",
-            "init/",
-            "lib/",
-            "media/",
-            "mnt/",
-            "opt/",
-            "proc/",
-            "root/",
-            "run/",
-            "sbin/",
-            "srv/",
-            "sys/",
-            "tmp/",
-            "usr/",
-            "var/",
+            "/bin/",
+            "/boot/",
+            "/dev/",
+            "/etc/",
+            "/home/",
+            "/init/",
+            "/lib/",
+            "/media/",
+            "/mnt/",
+            "/opt/",
+            "/proc/",
+            "/root/",
+            "/run/",
+            "/sbin/",
+            "/srv/",
+            "/sys/",
+            "/tmp/",
+            "/usr/",
+            "/var/",
             // Common container/cloud directories
-            "app/",
-            "code/",
+            "/app/",
+            "/code/",
             // macOS specific
-            "applications/",
-            "cores/",
-            "library/",
-            "private/",
-            "users/",
-            "system/",
-            "volumes/",
+            "/applications/",
+            "/cores/",
+            "/library/",
+            "/private/",
+            "/users/",
+            "/system/",
+            "/volumes/",
             // Windows specific
             "c:/",
             "c:\\",
@@ -77,6 +77,10 @@ namespace Aikido.Zen.Core.Vulnerabilities
             "%TEMP%",
             "%TMP%",
         };
+
+        private static readonly char[] PathStartNoise = { '/', '\\', '.', '?' };
+
+        private static readonly string[] NormalizedDangerousPathStarts = Array.ConvertAll(DangerousPathStarts, pathStart => pathStart.TrimStart(PathStartNoise));
 
         /// <summary>
         /// Detects potential path traversal attacks in a string
@@ -119,7 +123,6 @@ namespace Aikido.Zen.Core.Vulnerabilities
             ReadOnlySpan<char> inputSpan = input.AsSpan();
             ReadOnlySpan<char> pathSpan = path.AsSpan();
 
-
             bool inputHasUnsafeParts = ContainsUnsafePathParts(inputSpan);
             bool pathHasUnsafeParts = ContainsUnsafePathParts(pathSpan);
             if (inputHasUnsafeParts && pathHasUnsafeParts)
@@ -127,11 +130,11 @@ namespace Aikido.Zen.Core.Vulnerabilities
 
             if (checkPathStart)
             {
-                ReadOnlySpan<char> normalizedInputSpan = inputSpan.TrimStart("/\\.?".AsSpan());
-                ReadOnlySpan<char> normalizedPathSpan = pathSpan.TrimStart("/\\.?".AsSpan());
+                ReadOnlySpan<char> normalizedInputSpan = inputSpan.TrimStart(PathStartNoise.AsSpan());
+                ReadOnlySpan<char> normalizedPathSpan = pathSpan.TrimStart(PathStartNoise.AsSpan());
 
                 // Check for absolute path traversal
-                foreach (var start in DangerousPathStarts)
+                foreach (var start in NormalizedDangerousPathStarts)
                 {
                     ReadOnlySpan<char> startSpan = start.AsSpan();
 

--- a/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
@@ -128,13 +128,16 @@ namespace Aikido.Zen.Core.Vulnerabilities
 
             if (checkPathStart)
             {
+                ReadOnlySpan<char> normalizedInputSpan = SkipPathStartNoise(inputSpan);
+                ReadOnlySpan<char> normalizedPathSpan = SkipPathStartNoise(pathSpan);
+
                 // Check for absolute path traversal
                 foreach (var start in DangerousPathStarts)
                 {
                     ReadOnlySpan<char> startSpan = start.AsSpan();
 
-                    if (inputSpan.StartsWith(startSpan, StringComparison.OrdinalIgnoreCase) &&
-                        pathSpan.StartsWith(startSpan, StringComparison.OrdinalIgnoreCase))
+                    if (normalizedInputSpan.StartsWith(startSpan, StringComparison.OrdinalIgnoreCase) &&
+                        normalizedPathSpan.StartsWith(startSpan, StringComparison.OrdinalIgnoreCase))
                         return true;
                 }
             }
@@ -153,6 +156,31 @@ namespace Aikido.Zen.Core.Vulnerabilities
             }
 
             return false;
+        }
+
+        private static ReadOnlySpan<char> SkipPathStartNoise(ReadOnlySpan<char> path)
+        {
+            // //./etc/passwd -> /etc/passwd
+            // /././etc/passwd -> /etc/passwd
+
+            var i = 1; // start from second char
+
+            while (i < path.Length)
+            {
+                if (path[i] == '/' ||
+                    path[i] == '\\' ||
+                    path[i] == '.')
+                {
+                    i++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            // Slice one char behind so we do not trim the real prefix.
+            return path.Slice(i - 1);
         }
     }
 }

--- a/Aikido.Zen.DotNetCore/Patches/IOPatches.cs
+++ b/Aikido.Zen.DotNetCore/Patches/IOPatches.cs
@@ -31,6 +31,10 @@ namespace Aikido.Zen.DotNetCore.Patches
             Patch(harmony, typeof(File).GetMethod("WriteAllBytes", new[] { typeof(string), typeof(byte[]) }), nameof(PrefixFileWriteAllBytes));
             Patch(harmony, typeof(File).GetMethod("AppendAllText", new[] { typeof(string), typeof(string) }), nameof(PrefixFileAppendAllText));
 
+            // Path operations
+            Patch(harmony, typeof(Path).GetMethod("GetFullPath", new[] { typeof(string) }), nameof(PrefixPathGetFullPath));
+            Patch(harmony, typeof(Path).GetMethod("GetFullPath", new[] { typeof(string), typeof(string) }), nameof(PrefixPathGetFullPathWithBasePath));
+
             // Directory operations
             Patch(harmony, typeof(Directory).GetMethod("CreateDirectory", new[] { typeof(string) }), nameof(PrefixDirectoryCreateDirectory));
             Patch(harmony, typeof(Directory).GetMethod("Delete", new[] { typeof(string), typeof(bool) }), nameof(PrefixDirectoryDelete));
@@ -62,6 +66,11 @@ namespace Aikido.Zen.DotNetCore.Patches
         private static bool PrefixFileWriteAllText(string path, MethodBase __originalMethod) => OnFileOperation(new[] { path }, __originalMethod);
         private static bool PrefixFileWriteAllBytes(string path, MethodBase __originalMethod) => OnFileOperation(new[] { path }, __originalMethod);
         private static bool PrefixFileAppendAllText(string path, MethodBase __originalMethod) => OnFileOperation(new[] { path }, __originalMethod);
+        #endregion
+
+        #region Path Operation Prefixes
+        private static bool PrefixPathGetFullPath(string path, MethodBase __originalMethod) => OnFileOperation(new[] { path }, __originalMethod);
+        private static bool PrefixPathGetFullPathWithBasePath(string path, string basePath, MethodBase __originalMethod) => OnFileOperation(new[] { path, basePath }, __originalMethod);
         #endregion
 
         #region Directory Operation Prefixes

--- a/Aikido.Zen.DotNetFramework/Patches/IOPatches.cs
+++ b/Aikido.Zen.DotNetFramework/Patches/IOPatches.cs
@@ -36,6 +36,10 @@ namespace Aikido.Zen.DotNetFramework.Patches
             Patch(harmony, typeof(File).GetMethod("WriteAllBytes", new[] { typeof(string), typeof(byte[]) }), nameof(PrefixFileWriteAllBytes));
             Patch(harmony, typeof(File).GetMethod("AppendAllText", new[] { typeof(string), typeof(string) }), nameof(PrefixFileAppendAllText));
 
+            // Path operations
+            Patch(harmony, typeof(Path).GetMethod("GetFullPath", new[] { typeof(string) }), nameof(PrefixPathGetFullPath));
+            Patch(harmony, typeof(Path).GetMethod("GetFullPath", new[] { typeof(string), typeof(string) }), nameof(PrefixPathGetFullPathWithBasePath));
+
             // Directory operations
             Patch(harmony, typeof(Directory).GetMethod("CreateDirectory", new[] { typeof(string), typeof(DirectorySecurity) }), nameof(PrefixDirectoryCreateDirectory));
             Patch(harmony, typeof(Directory).GetMethod("Delete", new[] { typeof(string), typeof(bool) }), nameof(PrefixDirectoryDelete));
@@ -67,6 +71,11 @@ namespace Aikido.Zen.DotNetFramework.Patches
         private static bool PrefixFileWriteAllText(string path, MethodBase __originalMethod) => OnFileOperation(new[] { path }, __originalMethod);
         private static bool PrefixFileWriteAllBytes(string path, MethodBase __originalMethod) => OnFileOperation(new[] { path }, __originalMethod);
         private static bool PrefixFileAppendAllText(string path, MethodBase __originalMethod) => OnFileOperation(new[] { path }, __originalMethod);
+        #endregion
+
+        #region Path Operation Prefixes
+        private static bool PrefixPathGetFullPath(string path, MethodBase __originalMethod) => OnFileOperation(new[] { path }, __originalMethod);
+        private static bool PrefixPathGetFullPathWithBasePath(string path, string basePath, MethodBase __originalMethod) => OnFileOperation(new[] { path, basePath }, __originalMethod);
         #endregion
 
         #region Directory Operation Prefixes

--- a/Aikido.Zen.DotNetFramework/Patches/IOPatches.cs
+++ b/Aikido.Zen.DotNetFramework/Patches/IOPatches.cs
@@ -38,7 +38,6 @@ namespace Aikido.Zen.DotNetFramework.Patches
 
             // Path operations
             Patch(harmony, typeof(Path).GetMethod("GetFullPath", new[] { typeof(string) }), nameof(PrefixPathGetFullPath));
-            Patch(harmony, typeof(Path).GetMethod("GetFullPath", new[] { typeof(string), typeof(string) }), nameof(PrefixPathGetFullPathWithBasePath));
 
             // Directory operations
             Patch(harmony, typeof(Directory).GetMethod("CreateDirectory", new[] { typeof(string), typeof(DirectorySecurity) }), nameof(PrefixDirectoryCreateDirectory));
@@ -75,7 +74,6 @@ namespace Aikido.Zen.DotNetFramework.Patches
 
         #region Path Operation Prefixes
         private static bool PrefixPathGetFullPath(string path, MethodBase __originalMethod) => OnFileOperation(new[] { path }, __originalMethod);
-        private static bool PrefixPathGetFullPathWithBasePath(string path, string basePath, MethodBase __originalMethod) => OnFileOperation(new[] { path, basePath }, __originalMethod);
         #endregion
 
         #region Directory Operation Prefixes

--- a/Aikido.Zen.Test/IOPatcherTests.cs
+++ b/Aikido.Zen.Test/IOPatcherTests.cs
@@ -144,6 +144,35 @@ namespace Aikido.Zen.Test
             RunAndVerifyAttackFlag(paths, copyMethodInfo, expectAttack: true, expectBlocked: false);
         }
 
+        [TestCase("../secrets/key.txt")]
+        [TestCase("./../secrets/key.txt")]
+        [TestCase("..//secrets/key.txt")]
+        [TestCase("../../../etc/passwd")]
+        public void OnFileOperation_GetFullPathWithTraversal_ThrowsExceptionWhenBlocking(string unsafeInput)
+        {
+            Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "true");
+            var getFullPathMethodInfo = typeof(Path).GetMethod("GetFullPath", new[] { typeof(string) })!;
+            var pathArgument = Path.Combine("wwwroot/blogs", unsafeInput);
+            var paths = new[] { pathArgument };
+            _realContext.ParsedUserInput = new Dictionary<string, string> { { "query.path", unsafeInput } };
+
+            RunAndVerifyAttackFlag(paths, getFullPathMethodInfo, expectAttack: true, expectBlocked: true);
+        }
+
+        [TestCase("//./etc/passwd")]
+        [TestCase("/.//etc/passwd")]
+        [TestCase("/././etc/passwd")]
+        public void OnFileOperation_GetFullPathWithNormalizedAbsolutePayload_ThrowsExceptionWhenBlocking(string unsafeInput)
+        {
+            Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "true");
+            var getFullPathMethodInfo = typeof(Path).GetMethod("GetFullPath", new[] { typeof(string) })!;
+            var pathArgument = Path.Combine("wwwroot/blogs", unsafeInput);
+            var paths = new[] { pathArgument };
+            _realContext.ParsedUserInput = new Dictionary<string, string> { { "query.path", unsafeInput } };
+
+            RunAndVerifyAttackFlag(paths, getFullPathMethodInfo, expectAttack: true, expectBlocked: true);
+        }
+
         [TestCase("/etc/shadow")]
         [TestCase("c:/windows/system32/cmd.exe")]
         [TestCase("C:\\Windows\\System32\\cmd.exe")]

--- a/Aikido.Zen.Test/IOPatcherTests.cs
+++ b/Aikido.Zen.Test/IOPatcherTests.cs
@@ -161,14 +161,12 @@ namespace Aikido.Zen.Test
             RunAndVerifyAttackFlag(paths, copyMethodInfo, expectAttack: true, expectBlocked: false);
         }
 
-        [TestCase("../secrets/key.txt")]
-        [TestCase("./../secrets/key.txt")]
-        [TestCase("..//secrets/key.txt")]
-        [TestCase("../../../etc/passwd")]
-        public void OnFileOperation_GetFullPathWithTraversal_ThrowsExceptionWhenBlocking(string unsafeInput)
+        [Test]
+        public void OnFileOperation_GetFullPathWithTraversal_ThrowsExceptionWhenBlocking()
         {
             Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "true");
             var getFullPathMethodInfo = typeof(Path).GetMethod("GetFullPath", new[] { typeof(string) })!;
+            var unsafeInput = "../secrets/key.txt";
             var pathArgument = Path.Combine("wwwroot/blogs", unsafeInput);
             var paths = new[] { pathArgument };
             _realContext.ParsedUserInput = new Dictionary<string, string> { { "query.path", unsafeInput } };
@@ -176,13 +174,12 @@ namespace Aikido.Zen.Test
             RunAndVerifyAttackFlag(paths, getFullPathMethodInfo, expectAttack: true, expectBlocked: true);
         }
 
-        [TestCase("//./etc/passwd")]
-        [TestCase("/.//etc/passwd")]
-        [TestCase("/././etc/passwd")]
-        public void OnFileOperation_GetFullPathWithNormalizedAbsolutePayload_ThrowsExceptionWhenBlocking(string unsafeInput)
+        [Test]
+        public void OnFileOperation_GetFullPathWithNormalizedAbsolutePayload_ThrowsExceptionWhenBlocking()
         {
             Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "true");
             var getFullPathMethodInfo = typeof(Path).GetMethod("GetFullPath", new[] { typeof(string) })!;
+            var unsafeInput = "/././etc/passwd";
             var pathArgument = Path.Combine("wwwroot/blogs", unsafeInput);
             var paths = new[] { pathArgument };
             _realContext.ParsedUserInput = new Dictionary<string, string> { { "query.path", unsafeInput } };
@@ -190,25 +187,21 @@ namespace Aikido.Zen.Test
             RunAndVerifyAttackFlag(paths, getFullPathMethodInfo, expectAttack: true, expectBlocked: true);
         }
 
-        [TestCase("/etc/shadow")]
-        [TestCase("c:/windows/system32/cmd.exe")]
-        [TestCase("C:\\Windows\\System32\\cmd.exe")]
-        [TestCase("%WINDIR%\\system32\\notepad.exe")]
-        public void OnFileOperation_AbsoluteInput_ThrowsExceptionWhenBlocking(string absoluteInput)
+        [Test]
+        public void OnFileOperation_AbsoluteInput_ThrowsExceptionWhenBlocking()
         {
             Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "true");
+            var absoluteInput = "/etc/shadow";
             var paths = new[] { absoluteInput };
             _realContext.ParsedUserInput = new Dictionary<string, string> { { "path", absoluteInput } };
             RunAndVerifyAttackFlag(paths, _methodInfo, expectAttack: true, expectBlocked: true);
         }
 
-        [TestCase("/etc/shadow")]
-        [TestCase("c:/windows/system32/cmd.exe")]
-        [TestCase("C:\\Windows\\System32\\cmd.exe")]
-        [TestCase("%WINDIR%\\system32\\notepad.exe")]
-        public void OnFileOperation_AbsoluteInput_ReturnsTrueWhenNotBlocking(string absoluteInput)
+        [Test]
+        public void OnFileOperation_AbsoluteInput_ReturnsTrueWhenNotBlocking()
         {
             Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "false");
+            var absoluteInput = "/etc/shadow";
             var paths = new[] { absoluteInput };
             _realContext.ParsedUserInput = new Dictionary<string, string> { { "path", absoluteInput } };
             RunAndVerifyAttackFlag(paths, _methodInfo, expectAttack: true, expectBlocked: false);

--- a/Aikido.Zen.Test/testdata/data.PathTraversalDetector.json
+++ b/Aikido.Zen.Test/testdata/data.PathTraversalDetector.json
@@ -216,6 +216,30 @@
     "isTraversal": true
   },
   {
+    "input": "../secrets/key.txt",
+    "path": "wwwroot/blogs/../secrets/key.txt",
+    "description": "GetFullPath traversal payload with parent directory",
+    "isTraversal": true
+  },
+  {
+    "input": "./../secrets/key.txt",
+    "path": "wwwroot/blogs/./../secrets/key.txt",
+    "description": "GetFullPath traversal payload with current directory",
+    "isTraversal": true
+  },
+  {
+    "input": "..//secrets/key.txt",
+    "path": "wwwroot/blogs/..//secrets/key.txt",
+    "description": "GetFullPath traversal payload with repeated slash",
+    "isTraversal": true
+  },
+  {
+    "input": "../../../etc/passwd",
+    "path": "wwwroot/blogs/../../../etc/passwd",
+    "description": "GetFullPath traversal payload with multiple parent directories",
+    "isTraversal": true
+  },
+  {
     "input": "~/.ssh/id_rsa",
     "path": "C:\\files\\~/.ssh/id_rsa",
     "description": "Linux home directory shorthand",
@@ -232,6 +256,66 @@
     "path": "C:\\files\\\\\\.\\test.txt",
     "description": "Windows device namespace syntax (backslash)",
     "isTraversal": false
+  },
+  {
+    "input": "//./etc/passwd",
+    "path": "//./etc/passwd",
+    "description": "Normalized absolute Linux path with Windows device-style prefix",
+    "isTraversal": true
+  },
+  {
+    "input": "/.//etc/passwd",
+    "path": "/.//etc/passwd",
+    "description": "Normalized absolute Linux path with mixed current-directory markers",
+    "isTraversal": true
+  },
+  {
+    "input": "/././etc/passwd",
+    "path": "/././etc/passwd",
+    "description": "Normalized absolute Linux path with repeated current-directory markers",
+    "isTraversal": true
+  },
+  {
+    "input": "\\\\?\\C:\\Windows\\System32\\cmd.exe",
+    "path": "\\\\?\\C:\\Windows\\System32\\cmd.exe",
+    "description": "Windows extended-length device path with backslashes",
+    "isTraversal": true
+  },
+  {
+    "input": "\\\\.\\C:\\Windows\\System32\\cmd.exe",
+    "path": "\\\\.\\C:\\Windows\\System32\\cmd.exe",
+    "description": "Windows device namespace path with backslashes",
+    "isTraversal": true
+  },
+  {
+    "input": "//?/C:/Windows/System32/cmd.exe",
+    "path": "//?/C:/Windows/System32/cmd.exe",
+    "description": "Windows extended-length device path with slashes",
+    "isTraversal": true
+  },
+  {
+    "input": "//./C:/Windows/System32/cmd.exe",
+    "path": "//./C:/Windows/System32/cmd.exe",
+    "description": "Windows device namespace path with slashes",
+    "isTraversal": true
+  },
+  {
+    "input": "c:/windows/system32/cmd.exe",
+    "path": "c:/windows/system32/cmd.exe",
+    "description": "Windows drive absolute path with forward slashes",
+    "isTraversal": true
+  },
+  {
+    "input": "C:\\Windows\\System32\\cmd.exe",
+    "path": "C:\\Windows\\System32\\cmd.exe",
+    "description": "Windows drive absolute path with backslashes",
+    "isTraversal": true
+  },
+  {
+    "input": "%WINDIR%\\system32\\notepad.exe",
+    "path": "%WINDIR%\\system32\\notepad.exe",
+    "description": "Windows windir environment variable absolute path",
+    "isTraversal": true
   },
   {
     "input": "%PROGRAMFILES%",

--- a/Aikido.Zen.Tests.DotNetCore/Patches/IOPatchesTests.cs
+++ b/Aikido.Zen.Tests.DotNetCore/Patches/IOPatchesTests.cs
@@ -40,6 +40,8 @@ namespace Aikido.Zen.Tests.DotNetCore.Patches
         [TestCase(typeof(File), "WriteAllText", new[] { typeof(string), typeof(string) })]
         [TestCase(typeof(File), "WriteAllBytes", new[] { typeof(string), typeof(byte[]) })]
         [TestCase(typeof(File), "AppendAllText", new[] { typeof(string), typeof(string) })]
+        [TestCase(typeof(Path), "GetFullPath", new[] { typeof(string) })]
+        [TestCase(typeof(Path), "GetFullPath", new[] { typeof(string), typeof(string) })]
         [TestCase(typeof(Directory), "CreateDirectory", new[] { typeof(string) })]
         [TestCase(typeof(Directory), "Delete", new[] { typeof(string), typeof(bool) })]
         [TestCase(typeof(Directory), "GetFiles", new[] { typeof(string) })]
@@ -121,5 +123,6 @@ namespace Aikido.Zen.Tests.DotNetCore.Patches
                 }
             }
         }
+
     }
 }

--- a/Aikido.Zen.Tests.DotNetFramework/Patches/IOPatchesTests.cs
+++ b/Aikido.Zen.Tests.DotNetFramework/Patches/IOPatchesTests.cs
@@ -40,6 +40,7 @@ namespace Aikido.Zen.Tests.DotNetFramework.Patches
         [TestCase(typeof(File), "WriteAllText", new[] { typeof(string), typeof(string) })]
         [TestCase(typeof(File), "WriteAllBytes", new[] { typeof(string), typeof(byte[]) })]
         [TestCase(typeof(File), "AppendAllText", new[] { typeof(string), typeof(string) })]
+        [TestCase(typeof(Path), "GetFullPath", new[] { typeof(string) })]
         [TestCase(typeof(Directory), "CreateDirectory", new[] { typeof(string), typeof(DirectorySecurity) })]
         [TestCase(typeof(Directory), "Delete", new[] { typeof(string), typeof(bool) })]
         [TestCase(typeof(Directory), "GetFiles", new[] { typeof(string) })]


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Enabled path traversal QA tests by removing them from skips
* Added Path.GetFullPath patching to .NET Framework IO hooks
* Added Path.GetFullPath overload patches to .NET Core IO hooks
* Normalized path-start detection and removed forced lowercase comparisons


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112782257?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->