### PR TITLE
Increase API HttpClient timeout

### DIFF
--- a/Aikido.Zen.Core/Api/ApiClientHttpClientFactory.cs
+++ b/Aikido.Zen.Core/Api/ApiClientHttpClientFactory.cs
@@ -7,7 +7,7 @@ namespace Aikido.Zen.Core.Api
 {
     internal static class ApiClientHttpClientFactory
     {
-        internal static HttpClient Create(int timeoutInMS = 100000)
+        internal static HttpClient Create(int timeoutInMS = 90000)
         {
             var handler = new HttpClientHandler
             {

--- a/Aikido.Zen.Core/Api/ApiClientHttpClientFactory.cs
+++ b/Aikido.Zen.Core/Api/ApiClientHttpClientFactory.cs
@@ -7,7 +7,7 @@ namespace Aikido.Zen.Core.Api
 {
     internal static class ApiClientHttpClientFactory
     {
-        internal static HttpClient Create(int timeoutInMS = 60000)
+        internal static HttpClient Create(int timeoutInMS = 100000)
         {
             var handler = new HttpClientHandler
             {

--- a/Aikido.Zen.Test/ApiClientHttpClientFactoryTests.cs
+++ b/Aikido.Zen.Test/ApiClientHttpClientFactoryTests.cs
@@ -19,11 +19,11 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public void Create_Uses100SecondDefaultTimeout()
+        public void Create_Uses90SecondDefaultTimeout()
         {
             using var httpClient = ApiClientHttpClientFactory.Create();
 
-            Assert.That(httpClient.Timeout, Is.EqualTo(TimeSpan.FromMilliseconds(100000)));
+            Assert.That(httpClient.Timeout, Is.EqualTo(TimeSpan.FromMilliseconds(90000)));
         }
 
         [Test]

--- a/Aikido.Zen.Test/ApiClientHttpClientFactoryTests.cs
+++ b/Aikido.Zen.Test/ApiClientHttpClientFactoryTests.cs
@@ -19,11 +19,11 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public void Create_Uses60SecondDefaultTimeout()
+        public void Create_Uses100SecondDefaultTimeout()
         {
             using var httpClient = ApiClientHttpClientFactory.Create();
 
-            Assert.That(httpClient.Timeout, Is.EqualTo(TimeSpan.FromMilliseconds(60000)));
+            Assert.That(httpClient.Timeout, Is.EqualTo(TimeSpan.FromMilliseconds(100000)));
         }
 
         [Test]


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Increased API HttpClient default timeout from 60000ms to 90000ms.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112805449?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->