### PR TITLE
Record users with resolved client IP

### DIFF
--- a/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
@@ -33,7 +33,7 @@ namespace Aikido.Zen.DotNetCore.Middleware
                 var user = context.Items["Aikido.Zen.CurrentUser"] as User;
                 if (user != null)
                 {
-                    Agent.Instance.Context.AddUser(user, ipAddress: context.Connection.RemoteIpAddress?.ToString());
+                    Agent.Instance.Context.AddUser(user, ipAddress: aikidoContext.RemoteAddress);
                 }
 
                 // Attack wave detection needs to be run manually as it doesn't rely on method patching

--- a/Aikido.Zen.Tests.DotNetCore/BlockingMiddlewareTests.cs
+++ b/Aikido.Zen.Tests.DotNetCore/BlockingMiddlewareTests.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Aikido.Zen.Core;
+using Aikido.Zen.Core.Models;
+using Aikido.Zen.DotNetCore.Middleware;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+
+namespace Aikido.Zen.Tests.DotNetCore
+{
+    public class BlockingMiddlewareTests
+    {
+        /// <summary>
+        /// ContextMiddleware resolves the real client IP from configured proxy
+        /// headers (e.g. AIKIDO_CLIENT_IP_HEADER) and stores it on
+        /// Context.RemoteAddress. BlockingMiddleware must attribute the
+        /// authenticated user to that resolved value, not to
+        /// Connection.RemoteIpAddress which is just the previous TCP hop
+        /// (ingress/proxy pod) and therefore the same for every request.
+        /// </summary>
+        [Test]
+        public async Task InvokeAsync_RecordsUser_WithResolvedClientIpFromContext()
+        {
+            // Arrange
+            const string connectionRemoteIp = "10.0.0.5";   // previous TCP hop (e.g. ingress pod)
+            const string resolvedClientIp = "203.0.113.7";  // real client, already resolved by ContextMiddleware
+            const string userId = "user42";
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Scheme = "http";
+            httpContext.Request.Host = new HostString("test.local");
+            httpContext.Request.Path = "/api/test";
+            httpContext.Request.Method = "GET";
+            httpContext.Connection.RemoteIpAddress = IPAddress.Parse(connectionRemoteIp);
+            httpContext.Items["Aikido.Zen.Context"] = new Context
+            {
+                Method = "GET",
+                Route = "/api/test",
+                RemoteAddress = resolvedClientIp,
+            };
+            httpContext.Items["Aikido.Zen.CurrentUser"] = new User(userId, "User Forty Two");
+
+            try
+            {
+                Agent.Instance.Context.Config.Clear();
+                Agent.Instance.ClearContext();
+
+                var middleware = new BlockingMiddleware();
+
+                // Act
+                await middleware.InvokeAsync(httpContext, _ => Task.CompletedTask);
+
+                // Assert
+                var recorded = Agent.Instance.Context.Users.SingleOrDefault(u => u.Id == userId);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(recorded, Is.Not.Null, "User should have been recorded by BlockingMiddleware");
+                    Assert.That(recorded?.LastIpAddress, Is.EqualTo(resolvedClientIp));
+                });
+            }
+            finally
+            {
+                Agent.Instance.ClearContext();
+                Agent.Instance.Context.Config.Clear();
+            }
+        }
+    }
+}


### PR DESCRIPTION
`BlockingMiddleware` passes `context.Connection.RemoteIpAddress` to `Agent.Instance.Context.AddUser`, ignoring the client IP that `ContextMiddleware` already resolved on the same request via `GetClientIp` (which honors `AIKIDO_TRUST_PROXY` and `AIKIDO_CLIENT_IP_HEADER`). When the host runs behind a reverse proxy or service mesh — i.e., the standard ASP.NET Core deployment — every authenticated user is tagged with the previous TCP hop's pod/proxy IP instead of the real client IP.

### Symptom in production

Hosting an ASP.NET Core app behind a Cloudflare Tunnel + an Istio ingress gateway, with `AIKIDO_TRUST_PROXY=true` and `AIKIDO_CLIENT_IP_HEADER=CF-Connecting-IP`, the Users view shows entries like:

| User | Last IP Address |
|---|---|
| user A | `::ffff:10.230.0.33` |
| user B | `::ffff:10.230.0.33` |
| user C | `::ffff:10.230.0.24` |
| user D | `::ffff:10.230.0.24` |

`10.230.0.33` and `10.230.0.24` are the two `istio-ingress` gateway pod IPs in that cluster — confirmed by `kubectl get pods -n istio-system -o wide`. The real client IPs are present in `X-Forwarded-For` and `CF-Connecting-IP`; `GetClientIp` resolves them correctly; the user record just doesn't read them.

### Fix

`Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs:36` — one token:

```diff
- Agent.Instance.Context.AddUser(user, ipAddress: context.Connection.RemoteIpAddress?.ToString());
+ Agent.Instance.Context.AddUser(user, ipAddress: aikidoContext.RemoteAddress);
```

`aikidoContext.RemoteAddress` is set by `ContextMiddleware` (line 136: `RemoteAddress = GetClientIp(httpContext)`), and `GetClientIp` falls back to `Connection.RemoteIpAddress?.ToString() ?? string.Empty` (line 267) when no header is configured or trusted — so the non-proxied path is unchanged. Every other event path in this middleware (lines 43, 58) and `Agent.SendAttackEvent` (`Agent.cs:310`) already uses `RemoteAddress`; this call site was the lone outlier.

### Test

Adds `Aikido.Zen.Tests.DotNetCore/BlockingMiddlewareTests.cs` — the first test of `BlockingMiddleware`. Simulates the seam (a `DefaultHttpContext` whose `Connection.RemoteIpAddress` differs from `Context.RemoteAddress`) and asserts the recorded user's `LastIpAddress` matches the resolved value.

The bug was invisible to CI because the two adjacent layers were each well-tested in isolation — `ContextMiddleware.GetClientIp` has 13 tests covering `AIKIDO_CLIENT_IP_HEADER`, port stripping, private-IP skipping, etc.; `AgentContext.AddUser` has thorough storage/eviction/concurrency tests — but nothing crossed the seam between them.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Recorded users with resolved client IP instead of connection IP


<sup>[More info](https://app.aikido.dev/featurebranch/scan/114787321?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->