### PR TITLE
Use seconds for Retry-After header

### DIFF
--- a/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
@@ -67,7 +67,7 @@ namespace Aikido.Zen.DotNetCore.Middleware
 
                     if (effectiveConfig != null)
                     {
-                        context.Response.Headers.Add("Retry-After", effectiveConfig.WindowSizeInMS.ToString());
+                        context.Response.Headers.Add("Retry-After", GetRetryAfterHeaderValue(effectiveConfig));
                     }
 
                     await context.Response.WriteAsync($"You are rate limited by Aikido firewall. (Your IP: {remoteAddress})");
@@ -79,6 +79,11 @@ namespace Aikido.Zen.DotNetCore.Middleware
                 LogHelper.ErrorLog(Agent.Logger, $"Error blocking request: {ex.Message}");
             }
             await next(context);
+        }
+
+        internal static string GetRetryAfterHeaderValue(RateLimitingConfig config)
+        {
+            return Math.Ceiling(config.WindowSizeInMS / 1000.0).ToString();
         }
     }
 }

--- a/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
@@ -83,7 +83,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                         429,
                         $"You are rate limited by Aikido firewall. (Your IP: {HttpUtility.HtmlEncode(aikidoContext.RemoteAddress)})",
                         completeRequest,
-                        effectiveConfig?.WindowSizeInMS.ToString());
+                        effectiveConfig != null ? GetRetryAfterHeaderValue(effectiveConfig) : null);
                     return;
                 }
             }
@@ -111,6 +111,11 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
             // CompleteRequest short-circuits pipeline nicer than Response.End (no ThreadAbortException)
             // Stored as Action for easy unit testing
             completeRequest?.Invoke();
+        }
+
+        internal static string GetRetryAfterHeaderValue(RateLimitingConfig config)
+        {
+            return Math.Ceiling(config.WindowSizeInMS / 1000.0).ToString();
         }
     }
 }

--- a/Aikido.Zen.Tests.DotNetCore/BlockingMiddlewareTests.cs
+++ b/Aikido.Zen.Tests.DotNetCore/BlockingMiddlewareTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Aikido.Zen.Core;
+using Aikido.Zen.Core.Helpers;
 using Aikido.Zen.Core.Models;
 using Aikido.Zen.DotNetCore.Middleware;
 using Microsoft.AspNetCore.Http;
@@ -64,6 +65,85 @@ namespace Aikido.Zen.Tests.DotNetCore
                 Agent.Instance.ClearContext();
                 Agent.Instance.Context.Config.Clear();
             }
+        }
+
+        [Test]
+        public async Task InvokeAsync_RateLimitedResponse_SetsRetryAfterInSeconds()
+        {
+            const string route = "/api/retry-after-test";
+            const string remoteAddress = "198.51.100.42";
+
+            try
+            {
+                RateLimitingHelper.ResetCache(10000, 120 * 60 * 1000);
+                Agent.Instance.Context.Config.Clear();
+                Agent.Instance.ClearContext();
+                Agent.Instance.Context.UpdateRatelimitedRoutes(new[]
+                {
+                    new EndpointConfig
+                    {
+                        Method = "GET",
+                        Route = route,
+                        RateLimiting = new RateLimitingConfig
+                        {
+                            Enabled = true,
+                            MaxRequests = 1,
+                            WindowSizeInMS = 60000
+                        }
+                    }
+                });
+
+                var middleware = new BlockingMiddleware();
+                var nextCalls = 0;
+
+                await middleware.InvokeAsync(
+                    CreateHttpContext(route, remoteAddress),
+                    _ =>
+                    {
+                        nextCalls++;
+                        return Task.CompletedTask;
+                    });
+
+                var rateLimitedContext = CreateHttpContext(route, remoteAddress);
+
+                await middleware.InvokeAsync(
+                    rateLimitedContext,
+                    _ =>
+                    {
+                        nextCalls++;
+                        return Task.CompletedTask;
+                    });
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(rateLimitedContext.Response.StatusCode, Is.EqualTo(429));
+                    Assert.That(rateLimitedContext.Response.Headers["Retry-After"].ToString(), Is.EqualTo("60"));
+                    Assert.That(nextCalls, Is.EqualTo(1));
+                });
+            }
+            finally
+            {
+                RateLimitingHelper.ResetCache(10000, 120 * 60 * 1000);
+                Agent.Instance.ClearContext();
+                Agent.Instance.Context.Config.Clear();
+            }
+        }
+
+        private static DefaultHttpContext CreateHttpContext(string route, string remoteAddress)
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Scheme = "http";
+            httpContext.Request.Host = new HostString("test.local");
+            httpContext.Request.Path = route;
+            httpContext.Request.Method = "GET";
+            httpContext.Items["Aikido.Zen.Context"] = new Context
+            {
+                Method = "GET",
+                Route = route,
+                RemoteAddress = remoteAddress,
+            };
+
+            return httpContext;
         }
     }
 }

--- a/Aikido.Zen.Tests.DotNetFramework/BlockingModuleTests.cs
+++ b/Aikido.Zen.Tests.DotNetFramework/BlockingModuleTests.cs
@@ -106,6 +106,16 @@ namespace Aikido.Zen.Tests.DotNetFramework
         }
 
         [Test]
+        public void GetRetryAfterHeaderValue_ConvertsWindowMillisecondsToSeconds()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(BlockingModule.GetRetryAfterHeaderValue(new RateLimitingConfig { WindowSizeInMS = 60000 }), Is.EqualTo("60"));
+                Assert.That(BlockingModule.GetRetryAfterHeaderValue(new RateLimitingConfig { WindowSizeInMS = 1500 }), Is.EqualTo("2"));
+            });
+        }
+
+        [Test]
         public void GetUser_ReturnsContextUser()
         {
             var originalCurrent = HttpContext.Current;
@@ -134,5 +144,6 @@ namespace Aikido.Zen.Tests.DotNetFramework
                 HttpContext.Current = originalCurrent;
             }
         }
+
     }
 }


### PR DESCRIPTION
## Summary
- convert rate limit Retry-After header values from milliseconds to seconds
- cover both ASP.NET Core middleware and .NET Framework module behavior

## Tests
- dotnet test Aikido.Zen.Tests.DotNetCore/Aikido.Zen.Tests.DotNetCore.csproj --no-restore
- dotnet test Aikido.Zen.Tests.DotNetFramework/Aikido.Zen.Tests.DotNetFramework.csproj --no-restore -v minimal
- git diff --check

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Converted Retry-After header values from milliseconds to seconds in middleware and module


<sup>[More info](https://app.aikido.dev/featurebranch/scan/116827180?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->