### PR TITLE
Log transient API failures as warnings instead of errors

### DIFF
--- a/Aikido.Zen.Core/Agent.cs
+++ b/Aikido.Zen.Core/Agent.cs
@@ -140,7 +140,7 @@ namespace Aikido.Zen.Core
                     }
                     else
                     {
-                        LogHelper.ErrorLog(Logger, $"Heartbeat was not sent successfully: {response.Error}");
+                        LogHelper.WarningLog(Logger, $"Heartbeat was not sent successfully: {response.Error}");
                     }
                 }
             };

--- a/Aikido.Zen.Core/Api/Reporting.cs
+++ b/Aikido.Zen.Core/Api/Reporting.cs
@@ -29,12 +29,12 @@ namespace Aikido.Zen.Core.Api
             }
             catch (TaskCanceledException ex)
             {
-                LogHelper.ErrorLog(Agent.Logger, $"Error reporting event (possible timeout): {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, $"Failed to report event (possible timeout): {ex.Message}");
                 return new ReportingAPIResponse { Success = false, Error = "timeout" };
             }
             catch (Exception ex)
             {
-                LogHelper.ErrorLog(Agent.Logger, $"Error reporting event: {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, $"Failed to report event: {ex.Message}");
                 return new ReportingAPIResponse { Success = false, Error = "unknown_error" };
             }
         }
@@ -54,7 +54,7 @@ namespace Aikido.Zen.Core.Api
             }
             catch (Exception ex)
             {
-                LogHelper.ErrorLog(Agent.Logger, $"Error retrieving Firewall Lists: {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, $"Failed to retrieve Firewall Lists: {ex.Message}");
                 return new FirewallListsAPIResponse { Success = false, Error = "unknown_error" };
             }
         }

--- a/Aikido.Zen.Core/Api/Runtime.cs
+++ b/Aikido.Zen.Core/Api/Runtime.cs
@@ -25,12 +25,12 @@ namespace Aikido.Zen.Core.Api
             }
             catch (TaskCanceledException ex)
             {
-                LogHelper.ErrorLog(Agent.Logger, $"Error retrieving config last updated (possible timeout): {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, $"Failed to retrieve config last updated (possible timeout): {ex.Message}");
                 return new ConfigLastUpdatedAPIResponse { Success = false, Error = "timeout" };
             }
             catch (Exception ex)
             {
-                LogHelper.ErrorLog(Agent.Logger, $"Error retrieving config last updated: {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, $"Failed to retrieve config last updated: {ex.Message}");
                 return new ConfigLastUpdatedAPIResponse { Success = false, Error = "unknown_error" };
             }
         }
@@ -45,12 +45,12 @@ namespace Aikido.Zen.Core.Api
             }
             catch (TaskCanceledException ex)
             {
-                LogHelper.ErrorLog(Agent.Logger, $"Error retrieving config (possible timeout): {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, $"Failed to retrieve config (possible timeout): {ex.Message}");
                 return new ReportingAPIResponse { Success = false, Error = "timeout" };
             }
             catch (Exception ex)
             {
-                LogHelper.ErrorLog(Agent.Logger, $"Error retrieving config: {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, $"Failed to retrieve config: {ex.Message}");
                 return new ReportingAPIResponse { Success = false, Error = "unknown_error" };
             }
         }

--- a/Aikido.Zen.Core/Helpers/LogHelper.cs
+++ b/Aikido.Zen.Core/Helpers/LogHelper.cs
@@ -85,6 +85,36 @@ namespace Aikido.Zen.Core.Helpers
         }
 
         /// <summary>
+        /// Logs a warning message, after sanitizing the message.
+        /// </summary>
+        /// <param name="logger">The logger instance to use.</param>
+        /// <param name="message">The message to log.</param>
+        public static void WarningLog(ILogger logger, string message) => WarningLog(logger, null, message);
+
+        /// <summary>
+        /// Logs a warning message, after sanitizing the message.
+        /// </summary>
+        /// <param name="logger">The logger instance to use.</param>
+        /// <param name="exception">The exception associated with the warning, if any.</param>
+        /// <param name="message">The message to log.</param>
+        public static void WarningLog(ILogger logger, Exception exception, string message)
+        {
+            // Sanitize the message to prevent log injection
+            string sanitizedMessage = SanitizeMessage(message);
+
+            if (exception == null)
+            {
+                // we log the message to the outputs defined by the application
+                logger.LogWarning(sanitizedMessage);
+            }
+            else
+            {
+                // we log the message to the outputs defined by the application
+                logger.LogWarning(exception, sanitizedMessage);
+            }
+        }
+
+        /// <summary>
         /// Logs an information message, after sanitizing the message and applying rate limiting.
         /// </summary>
         /// <param name="logger">The logger instance to use.</param>

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -3,7 +3,9 @@ using Aikido.Zen.Core.Api;
 using Aikido.Zen.Core.Models;
 using Aikido.Zen.Core.Models.Events;
 using Aikido.Zen.Tests.Mocks;
+using Microsoft.Extensions.Logging;
 using Moq;
+using System.Collections.Concurrent;
 using System.Reflection;
 
 namespace Aikido.Zen.Test
@@ -260,6 +262,40 @@ namespace Aikido.Zen.Test
                 ),
                 Times.Once
             );
+        }
+
+        [Test]
+        public void Start_HeartbeatFailureCallback_LogsWarning()
+        {
+            var loggerMock = new Mock<ILogger>();
+            Agent.ConfigureLogger(loggerMock.Object);
+
+            try
+            {
+                _agent.Start();
+
+                var scheduledEventsField = typeof(Agent).GetField("_scheduledEvents", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.That(scheduledEventsField, Is.Not.Null);
+
+                var scheduledEvents = scheduledEventsField!.GetValue(_agent) as ConcurrentDictionary<string, Agent.ScheduledItem>;
+                Assert.That(scheduledEvents, Is.Not.Null);
+                Assert.That(scheduledEvents!.TryGetValue(Heartbeat.ScheduleId, out var scheduledItem), Is.True);
+                var callback = scheduledItem!.Callback;
+                Assert.That(callback, Is.Not.Null);
+
+                callback!(new Heartbeat(), new ReportingAPIResponse { Success = false, Error = "timeout" });
+
+                loggerMock.Verify(logger => logger.Log(
+                    It.Is<LogLevel>(level => level == LogLevel.Warning),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Heartbeat was not sent successfully: timeout")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+            }
+            finally
+            {
+                Agent.ConfigureLogger(null);
+            }
         }
 
         [Test]

--- a/Aikido.Zen.Test/Helpers/LogHelperTests.cs
+++ b/Aikido.Zen.Test/Helpers/LogHelperTests.cs
@@ -134,6 +134,22 @@ namespace Aikido.Zen.Test.Helpers
         }
 
         [Test]
+        public void WarningLog_WithException_ShouldLogExceptionAsWarning()
+        {
+            var message = "Test warning with exception";
+            var exception = new InvalidOperationException("test exception");
+
+            LogHelper.WarningLog(_loggerMock.Object, exception, message);
+
+            _loggerMock.Verify(logger => logger.Log(
+                It.Is<LogLevel>(level => level == LogLevel.Warning),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.EndsWith(message)),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+        }
+
+        [Test]
         public void AttackLog_ShouldSanitizeMessage_WhenMessageContainsDangerousCharacters()
         {
             var message = "Attack\nattempt\rwith\tdetails";

--- a/Aikido.Zen.Test/Helpers/LogHelperTests.cs
+++ b/Aikido.Zen.Test/Helpers/LogHelperTests.cs
@@ -103,6 +103,37 @@ namespace Aikido.Zen.Test.Helpers
         }
 
         [Test]
+        public void WarningLog_ShouldLogMessageAsWarning()
+        {
+            var message = "Test warning message";
+
+            LogHelper.WarningLog(_loggerMock.Object, message);
+
+            _loggerMock.Verify(logger => logger.Log(
+                It.Is<LogLevel>(level => level == LogLevel.Warning),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString().EndsWith(message)),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+        }
+
+        [Test]
+        public void WarningLog_ShouldSanitizeMessage_WhenMessageContainsDangerousCharacters()
+        {
+            var message = "Warning\nmessage\rwith\tdetails";
+            var expectedSanitizedContent = "Warningmessagewithdetails";
+
+            LogHelper.WarningLog(_loggerMock.Object, message);
+
+            _loggerMock.Verify(logger => logger.Log(
+                It.Is<LogLevel>(level => level == LogLevel.Warning),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString().Contains(expectedSanitizedContent)),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+        }
+
+        [Test]
         public void AttackLog_ShouldSanitizeMessage_WhenMessageContainsDangerousCharacters()
         {
             var message = "Attack\nattempt\rwith\tdetails";


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Changed transient API failure logs from errors to warnings across clients
* Added WarningLog helper overloads with message sanitization and exception support


<sup>[More info](https://app.aikido.dev/featurebranch/scan/118515355?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->