### PR TITLE
Detect status-sensitive extensions in attack wave detector 

### DIFF
--- a/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveDetector.cs
@@ -36,7 +36,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
         /// Checks if the request is part of an attack wave.
         /// Returns true when an attack wave should be reported.
         /// </summary>
-        internal bool Check(Context context, int? statusCode = null)
+        internal bool Check(Context context, int statusCode)
         {
             // Must have remote address to proceed
             if (string.IsNullOrWhiteSpace(context.RemoteAddress))
@@ -62,15 +62,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
                 }
 
                 // Run probe detector logic
-                if (statusCode.HasValue)
-                {
-                    // Post-response checks only count status-sensitive probes to avoid double-counting pre-request matches.
-                    if (!AttackWaveProbe.IsStatusSensitiveProbePath(context.Url, statusCode.Value))
-                    {
-                        return false;
-                    }
-                }
-                else if (!AttackWaveProbe.IsProbeRequest(context))
+                if (!AttackWaveProbe.IsProbeRequest(context, statusCode))
                 {
                     return false;
                 }

--- a/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveDetector.cs
@@ -36,7 +36,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
         /// Checks if the request is part of an attack wave.
         /// Returns true when an attack wave should be reported.
         /// </summary>
-        public bool Check(Context context)
+        internal bool Check(Context context, int? statusCode = null)
         {
             // Must have remote address to proceed
             if (string.IsNullOrWhiteSpace(context.RemoteAddress))
@@ -62,7 +62,15 @@ namespace Aikido.Zen.Core.Vulnerabilities
                 }
 
                 // Run probe detector logic
-                if (!AttackWaveProbe.IsProbeRequest(context))
+                if (statusCode.HasValue)
+                {
+                    // Post-response checks only count status-sensitive probes to avoid double-counting pre-request matches.
+                    if (!AttackWaveProbe.IsStatusSensitiveProbePath(context.Url, statusCode.Value))
+                    {
+                        return false;
+                    }
+                }
+                else if (!AttackWaveProbe.IsProbeRequest(context))
                 {
                     return false;
                 }
@@ -82,7 +90,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
             }
         }
 
-        public IList<SuspiciousRequest> GetSamplesForIp(string ip)
+        internal IList<SuspiciousRequest> GetSamplesForIp(string ip)
         {
             if (string.IsNullOrWhiteSpace(ip))
             {

--- a/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
@@ -145,8 +145,8 @@ namespace Aikido.Zen.Core.Vulnerabilities
                 var ext = lastDotIndex >= 0 ? filename.Substring(lastDotIndex + 1) : null;
                 if (!string.IsNullOrEmpty(ext) && ext != filename)
                 {
-                    if (FileExtensions.Contains(ext) ||
-                        (IsFailedStatus(statusCode) && StatusSensitiveFileExtensions.Contains(ext)))
+                    if (FileExtensions.Contains(ext)
+                        || (IsFailedStatus(statusCode) && StatusSensitiveFileExtensions.Contains(ext)))
                     {
                         return true;
                     }

--- a/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
@@ -15,7 +15,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
         private static readonly char[] QueryOrFragmentSeparators = { '?', '#' };
 
         private static readonly HashSet<string> FileExtensions = new HashSet<string>(
-            new[] { "env", "bak", "sql", "sqlite", "sqlite3", "db", "old", "save", "orig", "sqlitedb", "sqlite3db", "php", "php3", "php4", "php5", "phtml" },
+            new[] { "env", "bak", "sql", "sqlite", "sqlite3", "db", "old", "save", "orig", "sqlitedb", "sqlite3db", "php", "php3", "php4", "php5", "phtml", "java" },
             StringComparer.OrdinalIgnoreCase);
 
         private static readonly HashSet<string> FileNames = new HashSet<string>(

--- a/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
@@ -146,7 +146,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
                 if (!string.IsNullOrEmpty(ext) && ext != filename)
                 {
                     if (FileExtensions.Contains(ext)
-                        || (IsFailedStatus(statusCode) && StatusSensitiveFileExtensions.Contains(ext)))
+                        || (IsNotFoundStatus(statusCode) && StatusSensitiveFileExtensions.Contains(ext)))
                     {
                         return true;
                     }
@@ -168,9 +168,9 @@ namespace Aikido.Zen.Core.Vulnerabilities
             return false;
         }
 
-        private static bool IsFailedStatus(int statusCode)
+        private static bool IsNotFoundStatus(int statusCode)
         {
-            return statusCode < 200 || statusCode > 399;
+            return statusCode == 404;
         }
 
         private static List<string> ExtractPathSegments(string path)

--- a/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
@@ -15,7 +15,12 @@ namespace Aikido.Zen.Core.Vulnerabilities
         private static readonly char[] QueryOrFragmentSeparators = { '?', '#' };
 
         private static readonly HashSet<string> FileExtensions = new HashSet<string>(
-            new[] { "env", "bak", "sql", "sqlite", "sqlite3", "db", "old", "save", "orig", "sqlitedb", "sqlite3db", "php", "php3", "php4", "php5", "phtml", "java", "jsp", "jspx" },
+            new[] { "env", "bak", "sql", "sqlite", "sqlite3", "db", "old", "save", "orig", "sqlitedb", "sqlite3db" },
+            StringComparer.OrdinalIgnoreCase);
+
+        // Generic app-framework extensions are noisy unless the app failed to handle them.
+        private static readonly HashSet<string> StatusSensitiveFileExtensions = new HashSet<string>(
+            new[] { "php", "php3", "php4", "php5", "phtml", "java", "jsp", "jspx" },
             StringComparer.OrdinalIgnoreCase);
 
         private static readonly HashSet<string> FileNames = new HashSet<string>(
@@ -92,7 +97,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
             "../",
         };
 
-        public static bool IsProbeRequest(Context context)
+        internal static bool IsProbeRequest(Context context)
         {
             if (IsProbeMethod(context.Method))
             {
@@ -158,6 +163,34 @@ namespace Aikido.Zen.Core.Vulnerabilities
             }
 
             return false;
+        }
+
+        internal static bool IsStatusSensitiveProbePath(string path, int statusCode)
+        {
+            if (string.IsNullOrEmpty(path) || !IsFailedStatus(statusCode))
+            {
+                return false;
+            }
+
+            var segments = ExtractPathSegments(path);
+            var filename = segments.LastOrDefault();
+
+            // Known sensitive filenames are already counted by the pre-request probe check.
+            return !string.IsNullOrEmpty(filename)
+                && !FileNames.Contains(filename)
+                && HasStatusSensitiveExtension(filename);
+        }
+
+        private static bool HasStatusSensitiveExtension(string filename)
+        {
+            var lastDotIndex = filename.LastIndexOf('.');
+            var ext = lastDotIndex >= 0 ? filename.Substring(lastDotIndex + 1) : null;
+            return !string.IsNullOrEmpty(ext) && ext != filename && StatusSensitiveFileExtensions.Contains(ext);
+        }
+
+        private static bool IsFailedStatus(int statusCode)
+        {
+            return statusCode < 200 || statusCode > 399;
         }
 
         private static List<string> ExtractPathSegments(string path)

--- a/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
@@ -15,7 +15,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
         private static readonly char[] QueryOrFragmentSeparators = { '?', '#' };
 
         private static readonly HashSet<string> FileExtensions = new HashSet<string>(
-            new[] { "env", "bak", "sql", "sqlite", "sqlite3", "db", "old", "save", "orig", "sqlitedb", "sqlite3db", "php", "php3", "php4", "php5", "phtml", "java" },
+            new[] { "env", "bak", "sql", "sqlite", "sqlite3", "db", "old", "save", "orig", "sqlitedb", "sqlite3db", "php", "php3", "php4", "php5", "phtml", "java", "jsp", "jspx" },
             StringComparer.OrdinalIgnoreCase);
 
         private static readonly HashSet<string> FileNames = new HashSet<string>(

--- a/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
@@ -11,8 +11,11 @@ namespace Aikido.Zen.Core.Vulnerabilities
             new[] { "BADMETHOD", "BADHTTPMETHOD", "BADDATA", "BADMTHD", "BDMTHD" },
             StringComparer.OrdinalIgnoreCase);
 
+        private static readonly char[] PathSeparators = { '/' };
+        private static readonly char[] QueryOrFragmentSeparators = { '?', '#' };
+
         private static readonly HashSet<string> FileExtensions = new HashSet<string>(
-            new[] { "env", "bak", "sql", "sqlite", "sqlite3", "db", "old", "save", "orig", "sqlitedb", "sqlite3db" },
+            new[] { "env", "bak", "sql", "sqlite", "sqlite3", "db", "old", "save", "orig", "sqlitedb", "sqlite3db", "php" },
             StringComparer.OrdinalIgnoreCase);
 
         private static readonly HashSet<string> FileNames = new HashSet<string>(
@@ -121,10 +124,8 @@ namespace Aikido.Zen.Core.Vulnerabilities
                 return false;
             }
 
-            var normalized = path.ToLowerInvariant();
-
             // Split path into filename and directories, last segment is filename
-            var segments = normalized.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+            var segments = ExtractPathSegments(path);
             var filename = segments.LastOrDefault();
 
             if (!string.IsNullOrEmpty(filename))
@@ -136,7 +137,8 @@ namespace Aikido.Zen.Core.Vulnerabilities
                 }
 
                 // Match suspicious extensions
-                var ext = filename.Split('.').LastOrDefault();
+                var lastDotIndex = filename.LastIndexOf('.');
+                var ext = lastDotIndex >= 0 ? filename.Substring(lastDotIndex + 1) : null;
                 if (!string.IsNullOrEmpty(ext) && ext != filename && FileExtensions.Contains(ext))
                 {
                     return true;
@@ -156,6 +158,18 @@ namespace Aikido.Zen.Core.Vulnerabilities
             }
 
             return false;
+        }
+
+        private static List<string> ExtractPathSegments(string path)
+        {
+            var queryOrFragmentIndex = path.IndexOfAny(QueryOrFragmentSeparators);
+            var normalizedPath = queryOrFragmentIndex >= 0
+                ? path.Substring(0, queryOrFragmentIndex)
+                : path;
+
+            return normalizedPath
+                .Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries)
+                .ToList();
         }
 
         internal static bool QueryParamsContainDangerousPayload(IDictionary<string, string> query)

--- a/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
@@ -15,7 +15,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
         private static readonly char[] QueryOrFragmentSeparators = { '?', '#' };
 
         private static readonly HashSet<string> FileExtensions = new HashSet<string>(
-            new[] { "env", "bak", "sql", "sqlite", "sqlite3", "db", "old", "save", "orig", "sqlitedb", "sqlite3db", "php" },
+            new[] { "env", "bak", "sql", "sqlite", "sqlite3", "db", "old", "save", "orig", "sqlitedb", "sqlite3db", "php", "php3", "php4", "php5", "phtml" },
             StringComparer.OrdinalIgnoreCase);
 
         private static readonly HashSet<string> FileNames = new HashSet<string>(

--- a/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/AttackWave/AttackWaveProbe.cs
@@ -18,7 +18,6 @@ namespace Aikido.Zen.Core.Vulnerabilities
             new[] { "env", "bak", "sql", "sqlite", "sqlite3", "db", "old", "save", "orig", "sqlitedb", "sqlite3db" },
             StringComparer.OrdinalIgnoreCase);
 
-        // Generic app-framework extensions are noisy unless the app failed to handle them.
         private static readonly HashSet<string> StatusSensitiveFileExtensions = new HashSet<string>(
             new[] { "php", "php3", "php4", "php5", "phtml", "java", "jsp", "jspx" },
             StringComparer.OrdinalIgnoreCase);
@@ -97,14 +96,14 @@ namespace Aikido.Zen.Core.Vulnerabilities
             "../",
         };
 
-        internal static bool IsProbeRequest(Context context)
+        internal static bool IsProbeRequest(Context context, int statusCode)
         {
             if (IsProbeMethod(context.Method))
             {
                 return true;
             }
 
-            if (IsProbePath(context.Url))
+            if (IsProbePath(context.Url, statusCode))
             {
                 return true;
             }
@@ -122,7 +121,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
             return Methods.Contains(method ?? string.Empty);
         }
 
-        internal static bool IsProbePath(string path)
+        internal static bool IsProbePath(string path, int statusCode)
         {
             if (string.IsNullOrEmpty(path))
             {
@@ -144,9 +143,13 @@ namespace Aikido.Zen.Core.Vulnerabilities
                 // Match suspicious extensions
                 var lastDotIndex = filename.LastIndexOf('.');
                 var ext = lastDotIndex >= 0 ? filename.Substring(lastDotIndex + 1) : null;
-                if (!string.IsNullOrEmpty(ext) && ext != filename && FileExtensions.Contains(ext))
+                if (!string.IsNullOrEmpty(ext) && ext != filename)
                 {
-                    return true;
+                    if (FileExtensions.Contains(ext) ||
+                        (IsFailedStatus(statusCode) && StatusSensitiveFileExtensions.Contains(ext)))
+                    {
+                        return true;
+                    }
                 }
 
                 // Drop filename before checking directories
@@ -163,29 +166,6 @@ namespace Aikido.Zen.Core.Vulnerabilities
             }
 
             return false;
-        }
-
-        internal static bool IsStatusSensitiveProbePath(string path, int statusCode)
-        {
-            if (string.IsNullOrEmpty(path) || !IsFailedStatus(statusCode))
-            {
-                return false;
-            }
-
-            var segments = ExtractPathSegments(path);
-            var filename = segments.LastOrDefault();
-
-            // Known sensitive filenames are already counted by the pre-request probe check.
-            return !string.IsNullOrEmpty(filename)
-                && !FileNames.Contains(filename)
-                && HasStatusSensitiveExtension(filename);
-        }
-
-        private static bool HasStatusSensitiveExtension(string filename)
-        {
-            var lastDotIndex = filename.LastIndexOf('.');
-            var ext = lastDotIndex >= 0 ? filename.Substring(lastDotIndex + 1) : null;
-            return !string.IsNullOrEmpty(ext) && ext != filename && StatusSensitiveFileExtensions.Contains(ext);
         }
 
         private static bool IsFailedStatus(int statusCode)

--- a/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
@@ -36,14 +36,6 @@ namespace Aikido.Zen.DotNetCore.Middleware
                     Agent.Instance.Context.AddUser(user, ipAddress: aikidoContext.RemoteAddress);
                 }
 
-                // Attack wave detection needs to be run manually as it doesn't rely on method patching
-                var attackWaveDetector = Agent.Instance.AttackWaveDetector;
-                if (attackWaveDetector.Check(aikidoContext))
-                {
-                    var samples = attackWaveDetector.GetSamplesForIp(aikidoContext.RemoteAddress);
-                    Agent.Instance.SendAttackWaveEvent(aikidoContext, samples);
-                }
-
                 // block the request if the user is blocked
                 if (Agent.Instance.Context.IsBlocked(aikidoContext, out var reason))
                 {

--- a/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
@@ -106,6 +106,13 @@ namespace Aikido.Zen.DotNetCore.Middleware
             int statusCode = httpContext.Response.StatusCode;
             try
             {
+                var attackWaveDetector = Agent.Instance.AttackWaveDetector;
+                if (attackWaveDetector.Check(context, statusCode))
+                {
+                    var samples = attackWaveDetector.GetSamplesForIp(context.RemoteAddress);
+                    Agent.Instance.SendAttackWaveEvent(context, samples);
+                }
+
                 if (RouteHelper.ShouldAddRoute(context, statusCode))
                 {
                     LogHelper.DebugLog(Agent.Logger, "Adding route");

--- a/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
@@ -100,10 +100,22 @@ namespace Aikido.Zen.DotNetCore.Middleware
                 LogHelper.ErrorLog(Agent.Logger, $"Error capturing request: {e.Message}");
             }
 
-            await next(httpContext);
+            try
+            {
+                await next(httpContext);
+            }
+            catch
+            {
+                throw;
+            }
+            finally
+            {
+                HandleCompletedRequest(context, httpContext.Response.StatusCode);
+            }
+        }
 
-            // Capture the response status code and check if the route should be added
-            int statusCode = httpContext.Response.StatusCode;
+        private static void HandleCompletedRequest(Context context, int statusCode)
+        {
             try
             {
                 var attackWaveDetector = Agent.Instance.AttackWaveDetector;

--- a/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
@@ -104,10 +104,6 @@ namespace Aikido.Zen.DotNetCore.Middleware
             {
                 await next(httpContext);
             }
-            catch
-            {
-                throw;
-            }
             finally
             {
                 HandleCompletedRequest(context, httpContext.Response.StatusCode);

--- a/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
@@ -51,14 +51,6 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                     Agent.Instance.Context.AddUser(user, aikidoContext.RemoteAddress);
                 }
 
-                // Attack wave detection needs to be run manually as it doesn't rely on method patching
-                var attackWaveDetector = Agent.Instance.AttackWaveDetector;
-                if (attackWaveDetector.Check(aikidoContext))
-                {
-                    var samples = attackWaveDetector.GetSamplesForIp(aikidoContext.RemoteAddress);
-                    Agent.Instance.SendAttackWaveEvent(aikidoContext, samples);
-                }
-
                 // block the request if the user is blocked
                 if (Agent.Instance.Context.IsBlocked(aikidoContext, out var reason))
                 {

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -176,6 +176,13 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                 responseHandled = true;
 
                 int statusCode = httpContext.Response.StatusCode;
+                var attackWaveDetector = Agent.Instance.AttackWaveDetector;
+                if (attackWaveDetector.Check(aikidoContext, statusCode))
+                {
+                    var samples = attackWaveDetector.GetSamplesForIp(aikidoContext.RemoteAddress);
+                    Agent.Instance.SendAttackWaveEvent(aikidoContext, samples);
+                }
+
                 if (RouteHelper.ShouldAddRoute(aikidoContext, statusCode))
                 {
                     Agent.Instance.AddRoute(aikidoContext);

--- a/Aikido.Zen.Test/AttackWaveDetectorTests.cs
+++ b/Aikido.Zen.Test/AttackWaveDetectorTests.cs
@@ -98,8 +98,12 @@ namespace Aikido.Zen.Test
 
         [TestCase("/random.php")]
         [TestCase("/random.php?foo=bar")]
+        [TestCase("/random.php3")]
+        [TestCase("/random.php4?foo=bar")]
+        [TestCase("/random.php5")]
+        [TestCase("/random.phtml")]
         [TestCase("/nested/random.PHP")]
-        public void IsProbeRequest_DetectsPhpFileExtension(string url)
+        public void IsProbeRequest_DetectsPhpFileExtensions(string url)
         {
             Assert.That(
                 AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),

--- a/Aikido.Zen.Test/AttackWaveDetectorTests.cs
+++ b/Aikido.Zen.Test/AttackWaveDetectorTests.cs
@@ -28,7 +28,7 @@ namespace Aikido.Zen.Test
             var detector = NewDetector();
             var context = BuildContext(string.Empty, "/wp-config.php", "GET");
 
-            Assert.That(detector.Check(context), Is.False);
+            Assert.That(detector.Check(context, 404), Is.False);
         }
 
         [Test]
@@ -37,14 +37,14 @@ namespace Aikido.Zen.Test
             var detector = NewDetector();
             var context = BuildContext("::1", "/wp-config.php", "GET");
 
-            Assert.That(detector.Check(context), Is.False);
-            Assert.That(detector.Check(context), Is.True);
-            Assert.That(detector.Check(context), Is.False); // event already sent
+            Assert.That(detector.Check(context, 404), Is.False);
+            Assert.That(detector.Check(context, 404), Is.True);
+            Assert.That(detector.Check(context, 404), Is.False); // event already sent
 
             await Task.Delay(400); // allow both the timeframe and minTimeBetweenEvents to expire
 
-            Assert.That(detector.Check(context), Is.False);
-            Assert.That(detector.Check(context), Is.True);
+            Assert.That(detector.Check(context, 404), Is.False);
+            Assert.That(detector.Check(context, 404), Is.True);
         }
 
         [Test]
@@ -53,26 +53,17 @@ namespace Aikido.Zen.Test
             var detector = NewDetector();
             var context = BuildContext("::1", "/wp-config.php", "GET");
 
-            Assert.That(detector.Check(context), Is.False);
-            Assert.That(detector.Check(context), Is.True);
+            Assert.That(detector.Check(context, 200), Is.False);
+            Assert.That(detector.Check(context, 200), Is.True);
         }
 
-        [Test]
-        public void Check_IgnoresStatusSensitiveFileExtensionProbe_WithoutStatusCode()
+        [TestCase("/random.php")]
+        [TestCase("/random.java")]
+        [TestCase("/random.jsp")]
+        public void Check_IgnoresStatusSensitiveFileExtensionProbe_WhenStatusIsSuccessful(string url)
         {
             var detector = NewDetector();
-            var context = BuildContext("::1", "/random.php", "GET");
-
-            Assert.That(detector.Check(context), Is.False);
-            Assert.That(detector.Check(context), Is.False);
-            Assert.That(detector.GetSamplesForIp("::1"), Is.Empty);
-        }
-
-        [Test]
-        public void Check_IgnoresStatusSensitiveFileExtensionProbe_WhenStatusIsSuccessful()
-        {
-            var detector = NewDetector();
-            var context = BuildContext("::1", "/random.php", "GET");
+            var context = BuildContext("::1", url, "GET");
 
             Assert.That(detector.Check(context, 200), Is.False);
             Assert.That(detector.Check(context, 302), Is.False);
@@ -92,27 +83,16 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public void Check_WithStatusCode_DoesNotCountHighConfidenceProbeAgain()
-        {
-            var detector = NewDetector();
-            var context = BuildContext("::1", "/wp-config.php", "GET");
-
-            Assert.That(detector.Check(context), Is.False);
-            Assert.That(detector.Check(context, 404), Is.False);
-            Assert.That(detector.Check(context), Is.True);
-        }
-
-        [Test]
         public void TrackSample_StoresUniqueSamplesWithinLimit()
         {
             var detector = NewDetector(threshold: 10, timeframe: 1000, minBetweenEvents: 1000, maxSamples: 3);
             var ip = "::1";
 
-            detector.Check(BuildContext(ip, "/0/.env", "GET"));
-            detector.Check(BuildContext(ip, "/1/.env", "GET"));
-            detector.Check(BuildContext(ip, "/2/.env", "GET"));
-            detector.Check(BuildContext(ip, "/2/.env", "GET")); // duplicate
-            detector.Check(BuildContext(ip, "/3/.env", "GET")); // should be ignored due to max samples
+            detector.Check(BuildContext(ip, "/0/.env", "GET"), 404);
+            detector.Check(BuildContext(ip, "/1/.env", "GET"), 404);
+            detector.Check(BuildContext(ip, "/2/.env", "GET"), 404);
+            detector.Check(BuildContext(ip, "/2/.env", "GET"), 404); // duplicate
+            detector.Check(BuildContext(ip, "/3/.env", "GET"), 404); // should be ignored due to max samples
 
             var samples = detector.GetSamplesForIp(ip);
 
@@ -126,18 +106,18 @@ namespace Aikido.Zen.Test
         public void IsProbeRequest_DetectsDangerousSignals()
         {
             Assert.That(
-                AttackWaveProbe.IsProbeRequest(BuildContext("::1", "/.git/config", "GET")),
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", "/.git/config", "GET"), 200),
                 Is.True);
 
             Assert.That(
-                AttackWaveProbe.IsProbeRequest(BuildContext("::1", "/api", "BADMETHOD")),
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", "/api", "BADMETHOD"), 200),
                 Is.True);
 
             var contextWithQuery = BuildContext("::1", "/api", "GET", new Dictionary<string, string>
             {
                 { "test", "SELECT * FROM admin" }
             });
-            Assert.That(AttackWaveProbe.IsProbeRequest(contextWithQuery), Is.True);
+            Assert.That(AttackWaveProbe.IsProbeRequest(contextWithQuery, 200), Is.True);
         }
 
         [TestCase("/wp-config.php?foo=bar")]
@@ -147,7 +127,7 @@ namespace Aikido.Zen.Test
         public void IsProbeRequest_DetectsSuspiciousPath_WhenUrlContainsQueryString(string url)
         {
             Assert.That(
-                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET"), 200),
                 Is.True);
         }
 
@@ -158,60 +138,60 @@ namespace Aikido.Zen.Test
         [TestCase("/random.php5")]
         [TestCase("/random.phtml")]
         [TestCase("/nested/random.PHP")]
-        public void IsStatusSensitiveProbePath_DetectsPhpFileExtensions_WhenStatusIsNotSuccessful(string url)
+        public void IsProbeRequest_DetectsPhpFileExtensions_WhenStatusIsNotSuccessful(string url)
         {
             Assert.That(
-                AttackWaveProbe.IsStatusSensitiveProbePath(url, 404),
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET"), 404),
                 Is.True);
         }
 
         [TestCase("/random.java")]
         [TestCase("/random.java?foo=bar")]
         [TestCase("/nested/random.JAVA")]
-        public void IsStatusSensitiveProbePath_DetectsJavaFileExtension_WhenStatusIsNotSuccessful(string url)
+        public void IsProbeRequest_DetectsJavaFileExtension_WhenStatusIsNotSuccessful(string url)
         {
             Assert.That(
-                AttackWaveProbe.IsStatusSensitiveProbePath(url, 404),
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET"), 404),
                 Is.True);
         }
 
         [TestCase("/random.jsp")]
         [TestCase("/random.jspx?foo=bar")]
         [TestCase("/nested/random.JSP")]
-        public void IsStatusSensitiveProbePath_DetectsJspFileExtensions_WhenStatusIsNotSuccessful(string url)
+        public void IsProbeRequest_DetectsJspFileExtensions_WhenStatusIsNotSuccessful(string url)
         {
             Assert.That(
-                AttackWaveProbe.IsStatusSensitiveProbePath(url, 404),
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET"), 404),
                 Is.True);
         }
 
         [TestCase("/api/php/whatever")]
         [TestCase("/api/php/whatever?foo=bar")]
         [TestCase("/api/php")]
-        public void IsStatusSensitiveProbePath_IgnoresPhpPathSegmentWithoutPhpFileExtension(string url)
+        public void IsProbeRequest_IgnoresPhpPathSegmentWithoutPhpFileExtension(string url)
         {
             Assert.That(
-                AttackWaveProbe.IsStatusSensitiveProbePath(url, 404),
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET"), 404),
                 Is.False);
         }
 
         [TestCase("/api/java/whatever")]
         [TestCase("/api/java/whatever?foo=bar")]
         [TestCase("/api/java")]
-        public void IsStatusSensitiveProbePath_IgnoresJavaPathSegmentWithoutJavaFileExtension(string url)
+        public void IsProbeRequest_IgnoresJavaPathSegmentWithoutJavaFileExtension(string url)
         {
             Assert.That(
-                AttackWaveProbe.IsStatusSensitiveProbePath(url, 404),
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET"), 404),
                 Is.False);
         }
 
         [TestCase("/api/jsp/whatever")]
         [TestCase("/api/jsp/whatever?foo=bar")]
         [TestCase("/api/jspx")]
-        public void IsStatusSensitiveProbePath_IgnoresJspPathSegmentWithoutJspFileExtension(string url)
+        public void IsProbeRequest_IgnoresJspPathSegmentWithoutJspFileExtension(string url)
         {
             Assert.That(
-                AttackWaveProbe.IsStatusSensitiveProbePath(url, 404),
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET"), 404),
                 Is.False);
         }
 
@@ -219,11 +199,11 @@ namespace Aikido.Zen.Test
         public void IsProbeRequest_IgnoresBenignTraffic()
         {
             Assert.That(
-                AttackWaveProbe.IsProbeRequest(BuildContext("::1", "/api/users", "GET")),
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", "/api/users", "GET"), 404),
                 Is.False);
 
             Assert.That(
-                AttackWaveProbe.IsProbeRequest(BuildContext("::1", "/static/js/app.js", "GET")),
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", "/static/js/app.js", "GET"), 404),
                 Is.False);
         }
 

--- a/Aikido.Zen.Test/AttackWaveDetectorTests.cs
+++ b/Aikido.Zen.Test/AttackWaveDetectorTests.cs
@@ -85,6 +85,27 @@ namespace Aikido.Zen.Test
             Assert.That(AttackWaveProbe.IsProbeRequest(contextWithQuery), Is.True);
         }
 
+        [TestCase("/wp-config.php?foo=bar")]
+        [TestCase("https://example.com/wp-config.php?foo=bar")]
+        [TestCase("/backup.sql?foo=bar")]
+        [TestCase("https://example.com/backup.sql?foo=bar")]
+        public void IsProbeRequest_DetectsSuspiciousPath_WhenUrlContainsQueryString(string url)
+        {
+            Assert.That(
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                Is.True);
+        }
+
+        [TestCase("/random.php")]
+        [TestCase("/random.php?foo=bar")]
+        [TestCase("/nested/random.PHP")]
+        public void IsProbeRequest_DetectsPhpFileExtension(string url)
+        {
+            Assert.That(
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                Is.True);
+        }
+
         [Test]
         public void IsProbeRequest_IgnoresBenignTraffic()
         {

--- a/Aikido.Zen.Test/AttackWaveDetectorTests.cs
+++ b/Aikido.Zen.Test/AttackWaveDetectorTests.cs
@@ -120,6 +120,16 @@ namespace Aikido.Zen.Test
                 Is.True);
         }
 
+        [TestCase("/random.jsp")]
+        [TestCase("/random.jspx?foo=bar")]
+        [TestCase("/nested/random.JSP")]
+        public void IsProbeRequest_DetectsJspFileExtensions(string url)
+        {
+            Assert.That(
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                Is.True);
+        }
+
         [TestCase("/api/php/whatever")]
         [TestCase("/api/php/whatever?foo=bar")]
         [TestCase("/api/php")]
@@ -134,6 +144,16 @@ namespace Aikido.Zen.Test
         [TestCase("/api/java/whatever?foo=bar")]
         [TestCase("/api/java")]
         public void IsProbeRequest_IgnoresJavaPathSegmentWithoutJavaFileExtension(string url)
+        {
+            Assert.That(
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                Is.False);
+        }
+
+        [TestCase("/api/jsp/whatever")]
+        [TestCase("/api/jsp/whatever?foo=bar")]
+        [TestCase("/api/jspx")]
+        public void IsProbeRequest_IgnoresJspPathSegmentWithoutJspFileExtension(string url)
         {
             Assert.That(
                 AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),

--- a/Aikido.Zen.Test/AttackWaveDetectorTests.cs
+++ b/Aikido.Zen.Test/AttackWaveDetectorTests.cs
@@ -110,10 +110,30 @@ namespace Aikido.Zen.Test
                 Is.True);
         }
 
+        [TestCase("/random.java")]
+        [TestCase("/random.java?foo=bar")]
+        [TestCase("/nested/random.JAVA")]
+        public void IsProbeRequest_DetectsJavaFileExtension(string url)
+        {
+            Assert.That(
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                Is.True);
+        }
+
         [TestCase("/api/php/whatever")]
         [TestCase("/api/php/whatever?foo=bar")]
         [TestCase("/api/php")]
         public void IsProbeRequest_IgnoresPhpPathSegmentWithoutPhpFileExtension(string url)
+        {
+            Assert.That(
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                Is.False);
+        }
+
+        [TestCase("/api/java/whatever")]
+        [TestCase("/api/java/whatever?foo=bar")]
+        [TestCase("/api/java")]
+        public void IsProbeRequest_IgnoresJavaPathSegmentWithoutJavaFileExtension(string url)
         {
             Assert.That(
                 AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),

--- a/Aikido.Zen.Test/AttackWaveDetectorTests.cs
+++ b/Aikido.Zen.Test/AttackWaveDetectorTests.cs
@@ -60,27 +60,27 @@ namespace Aikido.Zen.Test
         [TestCase("/random.php")]
         [TestCase("/random.java")]
         [TestCase("/random.jsp")]
-        public void Check_IgnoresStatusSensitiveFileExtensionProbe_WhenStatusIsSuccessful(string url)
+        public void Check_IgnoresStatusSensitiveFileExtensionProbe_WhenStatusIsNot404(string url)
         {
             var detector = NewDetector();
             var context = BuildContext("::1", url, "GET");
 
             Assert.That(detector.Check(context, 200), Is.False);
             Assert.That(detector.Check(context, 302), Is.False);
+            Assert.That(detector.Check(context, 100), Is.False);
+            Assert.That(detector.Check(context, 400), Is.False);
+            Assert.That(detector.Check(context, 500), Is.False);
             Assert.That(detector.GetSamplesForIp("::1"), Is.Empty);
         }
 
-        [TestCase(100)]
-        [TestCase(400)]
-        [TestCase(404)]
-        [TestCase(500)]
-        public void Check_DetectsStatusSensitiveFileExtensionProbe_WhenStatusIsNotSuccessful(int statusCode)
+        [Test]
+        public void Check_DetectsStatusSensitiveFileExtensionProbe_WhenStatusIsNotFound()
         {
             var detector = NewDetector();
             var context = BuildContext("::1", "/random.php", "GET");
 
-            Assert.That(detector.Check(context, statusCode), Is.False);
-            Assert.That(detector.Check(context, statusCode), Is.True);
+            Assert.That(detector.Check(context, 404), Is.False);
+            Assert.That(detector.Check(context, 404), Is.True);
         }
 
         [Test]
@@ -139,7 +139,7 @@ namespace Aikido.Zen.Test
         [TestCase("/random.php5")]
         [TestCase("/random.phtml")]
         [TestCase("/nested/random.PHP")]
-        public void IsProbeRequest_DetectsPhpFileExtensions_WhenStatusIsNotSuccessful(string url)
+        public void IsProbeRequest_DetectsPhpFileExtensions_WhenStatusIsNotFound(string url)
         {
             Assert.That(
                 AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET"), 404),
@@ -149,7 +149,7 @@ namespace Aikido.Zen.Test
         [TestCase("/random.java")]
         [TestCase("/random.java?foo=bar")]
         [TestCase("/nested/random.JAVA")]
-        public void IsProbeRequest_DetectsJavaFileExtension_WhenStatusIsNotSuccessful(string url)
+        public void IsProbeRequest_DetectsJavaFileExtension_WhenStatusIsNotFound(string url)
         {
             Assert.That(
                 AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET"), 404),
@@ -159,7 +159,7 @@ namespace Aikido.Zen.Test
         [TestCase("/random.jsp")]
         [TestCase("/random.jspx?foo=bar")]
         [TestCase("/nested/random.JSP")]
-        public void IsProbeRequest_DetectsJspFileExtensions_WhenStatusIsNotSuccessful(string url)
+        public void IsProbeRequest_DetectsJspFileExtensions_WhenStatusIsNotFound(string url)
         {
             Assert.That(
                 AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET"), 404),

--- a/Aikido.Zen.Test/AttackWaveDetectorTests.cs
+++ b/Aikido.Zen.Test/AttackWaveDetectorTests.cs
@@ -70,6 +70,7 @@ namespace Aikido.Zen.Test
             Assert.That(detector.GetSamplesForIp("::1"), Is.Empty);
         }
 
+        [TestCase(100)]
         [TestCase(400)]
         [TestCase(404)]
         [TestCase(500)]

--- a/Aikido.Zen.Test/AttackWaveDetectorTests.cs
+++ b/Aikido.Zen.Test/AttackWaveDetectorTests.cs
@@ -106,6 +106,16 @@ namespace Aikido.Zen.Test
                 Is.True);
         }
 
+        [TestCase("/api/php/whatever")]
+        [TestCase("/api/php/whatever?foo=bar")]
+        [TestCase("/api/php")]
+        public void IsProbeRequest_IgnoresPhpPathSegmentWithoutPhpFileExtension(string url)
+        {
+            Assert.That(
+                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                Is.False);
+        }
+
         [Test]
         public void IsProbeRequest_IgnoresBenignTraffic()
         {

--- a/Aikido.Zen.Test/AttackWaveDetectorTests.cs
+++ b/Aikido.Zen.Test/AttackWaveDetectorTests.cs
@@ -48,6 +48,61 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
+        public void Check_DetectsHighConfidenceProbe()
+        {
+            var detector = NewDetector();
+            var context = BuildContext("::1", "/wp-config.php", "GET");
+
+            Assert.That(detector.Check(context), Is.False);
+            Assert.That(detector.Check(context), Is.True);
+        }
+
+        [Test]
+        public void Check_IgnoresStatusSensitiveFileExtensionProbe_WithoutStatusCode()
+        {
+            var detector = NewDetector();
+            var context = BuildContext("::1", "/random.php", "GET");
+
+            Assert.That(detector.Check(context), Is.False);
+            Assert.That(detector.Check(context), Is.False);
+            Assert.That(detector.GetSamplesForIp("::1"), Is.Empty);
+        }
+
+        [Test]
+        public void Check_IgnoresStatusSensitiveFileExtensionProbe_WhenStatusIsSuccessful()
+        {
+            var detector = NewDetector();
+            var context = BuildContext("::1", "/random.php", "GET");
+
+            Assert.That(detector.Check(context, 200), Is.False);
+            Assert.That(detector.Check(context, 302), Is.False);
+            Assert.That(detector.GetSamplesForIp("::1"), Is.Empty);
+        }
+
+        [TestCase(400)]
+        [TestCase(404)]
+        [TestCase(500)]
+        public void Check_DetectsStatusSensitiveFileExtensionProbe_WhenStatusIsNotSuccessful(int statusCode)
+        {
+            var detector = NewDetector();
+            var context = BuildContext("::1", "/random.php", "GET");
+
+            Assert.That(detector.Check(context, statusCode), Is.False);
+            Assert.That(detector.Check(context, statusCode), Is.True);
+        }
+
+        [Test]
+        public void Check_WithStatusCode_DoesNotCountHighConfidenceProbeAgain()
+        {
+            var detector = NewDetector();
+            var context = BuildContext("::1", "/wp-config.php", "GET");
+
+            Assert.That(detector.Check(context), Is.False);
+            Assert.That(detector.Check(context, 404), Is.False);
+            Assert.That(detector.Check(context), Is.True);
+        }
+
+        [Test]
         public void TrackSample_StoresUniqueSamplesWithinLimit()
         {
             var detector = NewDetector(threshold: 10, timeframe: 1000, minBetweenEvents: 1000, maxSamples: 3);
@@ -103,60 +158,60 @@ namespace Aikido.Zen.Test
         [TestCase("/random.php5")]
         [TestCase("/random.phtml")]
         [TestCase("/nested/random.PHP")]
-        public void IsProbeRequest_DetectsPhpFileExtensions(string url)
+        public void IsStatusSensitiveProbePath_DetectsPhpFileExtensions_WhenStatusIsNotSuccessful(string url)
         {
             Assert.That(
-                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                AttackWaveProbe.IsStatusSensitiveProbePath(url, 404),
                 Is.True);
         }
 
         [TestCase("/random.java")]
         [TestCase("/random.java?foo=bar")]
         [TestCase("/nested/random.JAVA")]
-        public void IsProbeRequest_DetectsJavaFileExtension(string url)
+        public void IsStatusSensitiveProbePath_DetectsJavaFileExtension_WhenStatusIsNotSuccessful(string url)
         {
             Assert.That(
-                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                AttackWaveProbe.IsStatusSensitiveProbePath(url, 404),
                 Is.True);
         }
 
         [TestCase("/random.jsp")]
         [TestCase("/random.jspx?foo=bar")]
         [TestCase("/nested/random.JSP")]
-        public void IsProbeRequest_DetectsJspFileExtensions(string url)
+        public void IsStatusSensitiveProbePath_DetectsJspFileExtensions_WhenStatusIsNotSuccessful(string url)
         {
             Assert.That(
-                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                AttackWaveProbe.IsStatusSensitiveProbePath(url, 404),
                 Is.True);
         }
 
         [TestCase("/api/php/whatever")]
         [TestCase("/api/php/whatever?foo=bar")]
         [TestCase("/api/php")]
-        public void IsProbeRequest_IgnoresPhpPathSegmentWithoutPhpFileExtension(string url)
+        public void IsStatusSensitiveProbePath_IgnoresPhpPathSegmentWithoutPhpFileExtension(string url)
         {
             Assert.That(
-                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                AttackWaveProbe.IsStatusSensitiveProbePath(url, 404),
                 Is.False);
         }
 
         [TestCase("/api/java/whatever")]
         [TestCase("/api/java/whatever?foo=bar")]
         [TestCase("/api/java")]
-        public void IsProbeRequest_IgnoresJavaPathSegmentWithoutJavaFileExtension(string url)
+        public void IsStatusSensitiveProbePath_IgnoresJavaPathSegmentWithoutJavaFileExtension(string url)
         {
             Assert.That(
-                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                AttackWaveProbe.IsStatusSensitiveProbePath(url, 404),
                 Is.False);
         }
 
         [TestCase("/api/jsp/whatever")]
         [TestCase("/api/jsp/whatever?foo=bar")]
         [TestCase("/api/jspx")]
-        public void IsProbeRequest_IgnoresJspPathSegmentWithoutJspFileExtension(string url)
+        public void IsStatusSensitiveProbePath_IgnoresJspPathSegmentWithoutJspFileExtension(string url)
         {
             Assert.That(
-                AttackWaveProbe.IsProbeRequest(BuildContext("::1", url, "GET")),
+                AttackWaveProbe.IsStatusSensitiveProbePath(url, 404),
                 Is.False);
         }
 

--- a/Aikido.Zen.Tests.DotNetCore/ContextMiddlewareTests.cs
+++ b/Aikido.Zen.Tests.DotNetCore/ContextMiddlewareTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -110,6 +111,49 @@ namespace Aikido.Zen.Tests.DotNetCore
                     Assert.That(Agent.Instance.Context.Requests, Is.EqualTo(0));
                     Assert.That(Agent.Instance.Context.Routes, Is.Empty);
                 });
+            }
+            finally
+            {
+                Agent.Instance.ClearContext();
+                Agent.Instance.Context.Config.Clear();
+                Environment.SetEnvironmentVariable("AIKIDO_DISABLE", originalDisable);
+            }
+        }
+
+        [Test]
+        public async Task InvokeAsync_WhenNextThrows_StillRunsAttackWaveDetection()
+        {
+            var originalDisable = Environment.GetEnvironmentVariable("AIKIDO_DISABLE");
+            const string ip = "203.0.113.211";
+
+            try
+            {
+                Environment.SetEnvironmentVariable("AIKIDO_DISABLE", "false");
+                Agent.Instance.Context.Config.Clear();
+                Agent.Instance.ClearContext();
+
+                RequestDelegate next = httpContext =>
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                    throw new InvalidOperationException("boom");
+                };
+
+                for (var i = 0; i < 15; i++)
+                {
+                    var context = new DefaultHttpContext();
+                    context.Request.Scheme = "http";
+                    context.Request.Host = new HostString("test.local");
+                    context.Request.Path = $"/api/pets/file{i}.env";
+                    context.Request.Method = "GET";
+                    context.Request.Body = new MemoryStream();
+                    context.Connection.RemoteIpAddress = IPAddress.Parse(ip);
+
+                    var ex = Assert.ThrowsAsync<InvalidOperationException>(
+                        () => _contextMiddleware.InvokeAsync(context, next));
+                    Assert.That(ex?.Message, Is.EqualTo("boom"));
+                }
+
+                Assert.That(Agent.Instance.Context.AttackWavesDetected, Is.EqualTo(1));
             }
             finally
             {


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Detected PHP, Java and JSP file extensions in attack probes
* Restricted status-sensitive file probes to 404 responses to reduce false-positives

**🔧 Refactors**
* Moved attack-wave detection to response completion and removed manual checks
* Changed AttackWave APIs to accept status code and reduced visibility


<sup>[More info](https://app.aikido.dev/featurebranch/scan/121787671?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->