### PR TITLE
Match node's path traversal completely

### DIFF
--- a/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
@@ -112,19 +112,32 @@ namespace Aikido.Zen.Core.Vulnerabilities
             if (inputHasUnsafeParts && pathHasUnsafeParts)
                 return true;
 
-            if (checkPathStart)
+            if (checkPathStart && StartsWithUnsafePath(pathSpan, inputSpan))
+                return true;
+
+            return false;
+        }
+
+        private static bool StartsWithUnsafePath(ReadOnlySpan<char> path, ReadOnlySpan<char> input)
+        {
+            ReadOnlySpan<char> normalizedInput = input.TrimStart(PathStartNoise.AsSpan());
+            ReadOnlySpan<char> normalizedPath = path.TrimStart(PathStartNoise.AsSpan());
+
+            // Check for absolute path traversal
+            foreach (var start in NormalizedDangerousPathStarts)
             {
-                ReadOnlySpan<char> normalizedInputSpan = inputSpan.TrimStart(PathStartNoise.AsSpan());
-                ReadOnlySpan<char> normalizedPathSpan = pathSpan.TrimStart(PathStartNoise.AsSpan());
+                ReadOnlySpan<char> startSpan = start.AsSpan();
 
-                // Check for absolute path traversal
-                foreach (var start in NormalizedDangerousPathStarts)
+                if (normalizedInput.StartsWith(startSpan, StringComparison.OrdinalIgnoreCase) &&
+                    normalizedPath.StartsWith(normalizedInput, StringComparison.OrdinalIgnoreCase))
                 {
-                    ReadOnlySpan<char> startSpan = start.AsSpan();
+                    // Bare root directories, such as /etc/ or /app/, are not enough to flag traversal.
+                    if (startSpan.Length > 0 &&
+                        startSpan[startSpan.Length - 1] == '/' &&
+                        normalizedInput.Equals(startSpan, StringComparison.OrdinalIgnoreCase))
+                        return false;
 
-                    if (normalizedInputSpan.StartsWith(startSpan, StringComparison.OrdinalIgnoreCase) &&
-                        normalizedPathSpan.StartsWith(normalizedInputSpan, StringComparison.OrdinalIgnoreCase))
-                        return true;
+                    return true;
                 }
             }
 

--- a/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
@@ -78,6 +78,8 @@ namespace Aikido.Zen.Core.Vulnerabilities
         };
 
         private static readonly char[] PathStartNoise = { '/', '\\', '.', '?' };
+        private const char DirectorySeparator = '/';
+        private const char AltDirectorySeparator = '\\';
 
         private static readonly string[] NormalizedDangerousPathStarts = Array.ConvertAll(DangerousPathStarts, pathStart => pathStart.TrimStart(PathStartNoise));
 
@@ -133,7 +135,8 @@ namespace Aikido.Zen.Core.Vulnerabilities
                 {
                     // Bare root directories, such as /etc/ or /app/, are not enough to flag traversal.
                     if (startSpan.Length > 0 &&
-                        startSpan[startSpan.Length - 1] == '/' &&
+                        (startSpan[startSpan.Length - 1] == DirectorySeparator ||
+                         startSpan[startSpan.Length - 1] == AltDirectorySeparator) &&
                         normalizedInput.Equals(startSpan, StringComparison.OrdinalIgnoreCase))
                         return false;
 

--- a/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
@@ -133,7 +133,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
                 if (normalizedInput.StartsWith(startSpan, StringComparison.OrdinalIgnoreCase) &&
                     normalizedPath.StartsWith(normalizedInput, StringComparison.OrdinalIgnoreCase))
                 {
-                    // Bare root directories, such as /etc/ or /app/, are not enough to flag traversal.
+                    // Bare root directories, such as /etc/, /app/, or C:\, are not enough to flag traversal.
                     if (startSpan.Length > 0 &&
                         (startSpan[startSpan.Length - 1] == DirectorySeparator ||
                          startSpan[startSpan.Length - 1] == AltDirectorySeparator) &&

--- a/Aikido.Zen.Test.End2End/UmbracoSampleAppTests.cs
+++ b/Aikido.Zen.Test.End2End/UmbracoSampleAppTests.cs
@@ -209,4 +209,38 @@ public class UmbracoSampleAppTests : WebApplicationTestBase
         var responseContent = await response.Content.ReadAsStringAsync();
         Assert.That(responseContent, Does.Contain("command executed"), "The command injection was unexpectedly blocked.");
     }
+
+    [TestCase("../../../../etc/passwd")]
+    [TestCase("../secret.txt")]
+    [TestCase("..\\secret.txt")]
+    [TestCase("..%2F..%2F..%2F..%2Fetc%2Fpasswd")]
+    [TestCase("..%2Fsecret.txt")]
+    [TestCase("..%5Csecret.txt")]
+    [CancelAfter(30000)]
+    public async Task TestPathTraversal_WithUnsafePath_ShouldBeBlocked(string path)
+    {
+        await SetMode(false, true);
+        SampleAppClient = CreateSampleAppFactory().CreateClient();
+
+        var response = await SampleAppClient.GetAsync($"/api/path-traversal?path={Uri.EscapeDataString(path)}");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
+    }
+
+    [TestCase("safe.txt")]
+    [TestCase("safe%2Etxt")]
+    [TestCase("another-safe.txt")]
+    [TestCase("third-safe.txt")]
+    [CancelAfter(30000)]
+    public async Task TestPathTraversal_WithSafePath_ShouldNotBeBlocked(string path)
+    {
+        await SetMode(false, true);
+        SampleAppClient = CreateSampleAppFactory().CreateClient();
+
+        var response = await SampleAppClient.GetAsync($"/api/path-traversal?path={Uri.EscapeDataString(path)}");
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(responseContent, Does.Contain("safe file"));
+    }
 }

--- a/Aikido.Zen.Test/IOSinkTests.cs
+++ b/Aikido.Zen.Test/IOSinkTests.cs
@@ -172,6 +172,30 @@ namespace Aikido.Zen.Test
             Assert.That(contextToPass.AttackDetected, Is.True);
         }
 
+        [TestCase(true, Description = "Unsafe source")]
+        [TestCase(false, Description = "Unsafe destination")]
+        public void OnFileOperation_FileMoveWithUnsafePath_ThrowsExceptionWhenBlocking(bool unsafeSource)
+        {
+            Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "true");
+            var moveMethodInfo = typeof(File).GetMethod("Move", new[] { typeof(string), typeof(string) })!;
+            var unsafeInput = "../../secrets.txt";
+            var safePath = "/app/uploads/image.jpg";
+            var unsafePath = $"/app/static/{unsafeInput}";
+            _realContext.ParsedUserInput = new Dictionary<string, string> { { "body.file.matches", unsafeInput } };
+            var contextToPass = _mockContext.Object;
+            contextToPass.ParsedUserInput = _realContext.ParsedUserInput;
+            contextToPass.AttackDetected = false;
+
+            Assert.Throws<AikidoException>(
+                () => OnFileOperationTwoPaths(
+                    unsafeSource ? unsafePath : safePath,
+                    unsafeSource ? safePath : unsafePath,
+                    moveMethodInfo,
+                    contextToPass),
+                "Expected AikidoException for blocked path traversal.");
+            Assert.That(contextToPass.AttackDetected, Is.True);
+        }
+
         [Test]
         public void OnFileOperation_GetFullPathWithTraversal_ThrowsExceptionWhenBlocking()
         {
@@ -226,6 +250,29 @@ namespace Aikido.Zen.Test
             var absoluteInput = "/etc/shadow";
             _realContext.ParsedUserInput = new Dictionary<string, string> { { "path", absoluteInput } };
             RunAndVerifyAttackFlag(absoluteInput, _methodInfo, expectAttack: true, expectBlocked: false);
+        }
+
+        [Test]
+        public void OnFileOperation_DirectoryGetFilesWithUserInputPathTraversal_ThrowsExceptionWhenBlocking()
+        {
+            Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "true");
+            var getFilesMethodInfo = typeof(Directory).GetMethod("GetFiles", new[] { typeof(string) })!;
+            var unsafeInput = "../secrets";
+            var pathArgument = $"/var/www/{unsafeInput}";
+            _realContext.ParsedUserInput = new Dictionary<string, string> { { "query.dir", unsafeInput } };
+
+            RunAndVerifyAttackFlag(pathArgument, getFilesMethodInfo, expectAttack: true, expectBlocked: true);
+        }
+
+        [Test]
+        public void OnFileOperation_DirectoryGetFilesWithAbsoluteUserInput_ThrowsExceptionWhenBlocking()
+        {
+            Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "true");
+            var getFilesMethodInfo = typeof(Directory).GetMethod("GetFiles", new[] { typeof(string) })!;
+            var absoluteInput = "/etc/some_directory";
+            _realContext.ParsedUserInput = new Dictionary<string, string> { { "body.file.matches", absoluteInput } };
+
+            RunAndVerifyAttackFlag(absoluteInput, getFilesMethodInfo, expectAttack: true, expectBlocked: true);
         }
 
         [Test]

--- a/Aikido.Zen.Test/PathTraversalDetectorTests.cs
+++ b/Aikido.Zen.Test/PathTraversalDetectorTests.cs
@@ -67,6 +67,16 @@ namespace Aikido.Zen.Test
             Assert.That(result, Is.False);
         }
 
+        [Test]
+        public void DetectPathTraversal_WithPathStartCheckDisabled_IgnoresAbsolutePath()
+        {
+            // Act
+            var result = PathTraversalDetector.DetectPathTraversal("/etc/passwd", "/etc/passwd", checkPathStart: false);
+
+            // Assert
+            Assert.That(result, Is.False);
+        }
+
 
         public static IEnumerable<TestCaseData> GetTestData()
         {

--- a/Aikido.Zen.Test/PathTraversalHelperTests.cs
+++ b/Aikido.Zen.Test/PathTraversalHelperTests.cs
@@ -6,6 +6,7 @@ using Aikido.Zen.Core.Sinks;
 using Aikido.Zen.Tests.Mocks;
 using Moq;
 using System.Reflection;
+using System.Text.Json;
 
 namespace Aikido.Zen.Test.Helpers
 {
@@ -64,6 +65,62 @@ namespace Aikido.Zen.Test.Helpers
             Assert.That(_context.AttackDetected, Is.EqualTo(expectedAttack));
         }
 
+        [TestCase("..%2Fsecrets%2Fkey.txt", Description = "Single-encoded traversal")]
+        [TestCase("%252e%252e%252fsecrets%252fkey.txt", Description = "Double-encoded traversal")]
+        public async Task DetectPathTraversal_WithUriDecodedParsedInput_DetectsAttack(string encodedInput)
+        {
+            Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "false");
+
+            using var bodyStream = new MemoryStream();
+            var parsed = await HttpHelper.ReadAndFlattenHttpDataAsync(
+                new Dictionary<string, string>(),
+                new Dictionary<string, string> { { "path", encodedInput } },
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                bodyStream,
+                "text/plain");
+            _context.ParsedUserInput = parsed.FlattenedData;
+
+            var filename = "wwwroot/blogs/../secrets/key.txt";
+
+            bool result = DetectPathTraversal(filename, _context, ModuleName, Operation);
+
+            Assert.That(parsed.FlattenedData["query.path"], Is.EqualTo(encodedInput));
+            Assert.That(parsed.FlattenedData["query.path|decoded"], Is.EqualTo("../secrets/key.txt"));
+            Assert.That(result, Is.True);
+            Assert.That(_context.AttackDetected, Is.True);
+        }
+
+        [TestCaseSource(nameof(GetUriEncodedPathTraversalTestData))]
+        public async Task DetectPathTraversal_WithUriEncodedParsedInput_MatchesDetectorFixture(string encodedInput, string decodedInput, string path, string description, bool expectedAttack)
+        {
+            Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "false");
+
+            using var bodyStream = new MemoryStream();
+            var parsed = await HttpHelper.ReadAndFlattenHttpDataAsync(
+                new Dictionary<string, string>(),
+                new Dictionary<string, string> { { "path", encodedInput } },
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                bodyStream,
+                "text/plain");
+            _context.ParsedUserInput = parsed.FlattenedData;
+
+            bool result = DetectPathTraversal(path, _context, ModuleName, Operation);
+
+            Assert.That(parsed.FlattenedData["query.path"], Is.EqualTo(encodedInput));
+            if (encodedInput == decodedInput)
+            {
+                Assert.That(parsed.FlattenedData.ContainsKey("query.path|decoded"), Is.False);
+            }
+            else
+            {
+                Assert.That(parsed.FlattenedData["query.path|decoded"], Is.EqualTo(decodedInput));
+            }
+            Assert.That(result, Is.EqualTo(expectedAttack), description);
+            Assert.That(_context.AttackDetected, Is.EqualTo(expectedAttack), description);
+        }
+
         [Test]
         public async Task DetectPathTraversal_WhenAttackDetected_ReportsFilenameMetadata()
         {
@@ -116,6 +173,48 @@ namespace Aikido.Zen.Test.Helpers
                 "fs_op",
                 _ => result);
             return result.AttackKind.HasValue;
+        }
+
+        public static IEnumerable<TestCaseData> GetUriEncodedPathTraversalTestData()
+        {
+            var jsonData = File.ReadAllText("testdata/data.PathTraversalDetector.json");
+            var testCases = JsonSerializer.Deserialize<List<PathTraversalTestCase>>(jsonData, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            }) ?? new List<PathTraversalTestCase>();
+
+            for (var i = 0; i < testCases.Count; i++)
+            {
+                var testCase = testCases[i];
+                var input = testCase.Input ?? string.Empty;
+                var path = testCase.Path ?? string.Empty;
+                var onceEncoded = Uri.EscapeDataString(input);
+                var twiceEncoded = Uri.EscapeDataString(onceEncoded);
+
+                yield return new TestCaseData(
+                    onceEncoded,
+                    input,
+                    path,
+                    testCase.Description,
+                    testCase.IsTraversal
+                ).SetName($"DecodedFlow_Once_{i}_{testCase.Description}");
+
+                yield return new TestCaseData(
+                    twiceEncoded,
+                    input,
+                    path,
+                    testCase.Description,
+                    testCase.IsTraversal
+                ).SetName($"DecodedFlow_Twice_{i}_{testCase.Description}");
+            }
+        }
+
+        private class PathTraversalTestCase
+        {
+            public string? Input { get; set; }
+            public string? Path { get; set; }
+            public string? Description { get; set; }
+            public bool IsTraversal { get; set; }
         }
     }
 }

--- a/Aikido.Zen.Test/testdata/data.PathTraversalDetector.json
+++ b/Aikido.Zen.Test/testdata/data.PathTraversalDetector.json
@@ -308,8 +308,14 @@
   {
     "input": "C:\\",
     "path": "C:\\file.txt",
-    "description": "Windows drive root directory input with file path",
-    "isTraversal": true
+    "description": "Bare Windows drive root directory input with file path is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "C:/",
+    "path": "C:/file.txt",
+    "description": "Bare Windows drive root directory input with forward slash file path is not traversal",
+    "isTraversal": false
   },
   {
     "input": "D:/logs/app.log",

--- a/Aikido.Zen.Test/testdata/data.PathTraversalDetector.json
+++ b/Aikido.Zen.Test/testdata/data.PathTraversalDetector.json
@@ -300,6 +300,42 @@
     "isTraversal": true
   },
   {
+    "input": "C:\\file.txt",
+    "path": "C:\\file.txt",
+    "description": "Windows drive root file path",
+    "isTraversal": true
+  },
+  {
+    "input": "C:\\",
+    "path": "C:\\file.txt",
+    "description": "Windows drive root directory input with file path",
+    "isTraversal": true
+  },
+  {
+    "input": "D:/logs/app.log",
+    "path": "D:/logs/app.log",
+    "description": "Windows secondary drive absolute path with forward slashes",
+    "isTraversal": true
+  },
+  {
+    "input": "C:\\files\\..\\secrets\\key.txt",
+    "path": "C:\\files\\..\\secrets\\key.txt",
+    "description": "Windows drive absolute path with parent directory traversal",
+    "isTraversal": true
+  },
+  {
+    "input": "..\\..//secrets/config.json",
+    "path": "C:\\files\\..\\..//secrets/config.json",
+    "description": "Mixed separator parent directory traversal",
+    "isTraversal": true
+  },
+  {
+    "input": "C:\\file.txt",
+    "path": "C:\\files\\C:\\file.txt",
+    "description": "Embedded Windows drive path is not root access",
+    "isTraversal": false
+  },
+  {
     "input": "c:\\windows\\system32\\cmd.exe",
     "path": "C:\\Windows\\System32\\cmd.exe",
     "description": "Windows drive absolute path with case mismatch",
@@ -330,6 +366,84 @@
     "isTraversal": true
   },
   {
+    "input": "/etc/hack/config",
+    "path": "/etc/app/config",
+    "description": "Absolute Linux path in different folder",
+    "isTraversal": false
+  },
+  {
+    "input": "/etc/config",
+    "path": "/etc/app/data/etc/config",
+    "description": "Absolute Linux path inside another folder",
+    "isTraversal": false
+  },
+  {
+    "input": "/etc",
+    "path": "/etc/app",
+    "description": "Bare Linux etc directory without trailing separator is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/etc/",
+    "path": "/etc/app/test.txt",
+    "description": "Bare Linux etc directory with trailing separator is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/etc/",
+    "path": "/etc/app/",
+    "description": "Bare Linux etc directory with trailing separator and app directory path is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/etc",
+    "path": "/etc",
+    "description": "Bare Linux etc directory is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/etc/",
+    "path": "/etc/",
+    "description": "Bare Linux etc directory with trailing separator is not traversal by itself",
+    "isTraversal": false
+  },
+  {
+    "input": "/etc",
+    "path": "/etc/./passwd",
+    "description": "Normalized Linux etc directory alone is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/etc/",
+    "path": "/etc/./passwd",
+    "description": "Normalized Linux etc directory with trailing separator alone is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/etc",
+    "path": "//etc//passwd",
+    "description": "Repeated slash Linux etc directory alone is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/etc/",
+    "path": "//etc//passwd",
+    "description": "Repeated slash Linux etc directory with trailing separator alone is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/etc/app",
+    "path": "/etc/app/file.txt",
+    "description": "Absolute Linux directory input with file path",
+    "isTraversal": true
+  },
+  {
+    "input": "/etc/app/file.txt",
+    "path": "/etc/app/file.txt",
+    "description": "Absolute Linux file path under etc app",
+    "isTraversal": true
+  },
+  {
     "input": "/home/user/file1.txt",
     "path": "/home/user/file2.txt",
     "description": "Absolute path different files",
@@ -339,6 +453,12 @@
     "input": "/home/user/file.txt",
     "path": "/home/user/file.txt",
     "description": "Absolute path same files",
+    "isTraversal": true
+  },
+  {
+    "input": "/home/user/.aws/credentials",
+    "path": "/home/user/.aws/credentials",
+    "description": "AWS credentials absolute path",
     "isTraversal": true
   },
   {
@@ -357,6 +477,186 @@
     "input": "/home/site",
     "path": "/home/site-backup/file.txt",
     "description": "Absolute Linux sibling prefix path",
+    "isTraversal": true
+  },
+  {
+    "input": "/var/backups",
+    "path": "/var/backups/file.txt",
+    "description": "Linux var backups directory input with file path",
+    "isTraversal": true
+  },
+  {
+    "input": "/var/backups/file.txt",
+    "path": "/var/backups/file.txt",
+    "description": "Linux var backups file path",
+    "isTraversal": true
+  },
+  {
+    "input": "/var/a",
+    "path": "/var/a",
+    "description": "Linux var single subdirectory path",
+    "isTraversal": true
+  },
+  {
+    "input": "/var/a",
+    "path": "/var/a/b",
+    "description": "Linux var directory input with child directory path",
+    "isTraversal": true
+  },
+  {
+    "input": "/var/a",
+    "path": "/var/a/b/test.txt",
+    "description": "Linux var directory input with nested file path",
+    "isTraversal": true
+  },
+  {
+    "input": "/var/",
+    "path": "/var/a",
+    "description": "Bare Linux var directory with trailing separator is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/var/",
+    "path": "/var/b",
+    "description": "Bare Linux var directory with trailing separator and sibling path is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/var/",
+    "path": "/var/b/test.txt",
+    "description": "Bare Linux var directory with trailing separator and nested sibling path is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/var/b",
+    "path": "/var/a",
+    "description": "Linux var sibling directory is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/var/b/test.txt",
+    "path": "/var/a",
+    "description": "Linux var sibling nested file is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/app/config",
+    "path": "/app/config/secret.yml",
+    "description": "Container app config directory input with secret path",
+    "isTraversal": true
+  },
+  {
+    "input": "/app/config/secret.yml",
+    "path": "/app/config/secret.yml",
+    "description": "Container app config secret path",
+    "isTraversal": true
+  },
+  {
+    "input": "/app",
+    "path": "/app/test.txt",
+    "description": "Bare container app directory without trailing separator is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/app/",
+    "path": "/app/test.txt",
+    "description": "Bare container app directory with trailing separator is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/app/",
+    "path": "/app/",
+    "description": "Bare container app directory with trailing separator is not traversal by itself",
+    "isTraversal": false
+  },
+  {
+    "input": "/code/src",
+    "path": "/code/src/index.js",
+    "description": "Container code source directory input with file path",
+    "isTraversal": true
+  },
+  {
+    "input": "/code/src/index.js",
+    "path": "/code/src/index.js",
+    "description": "Container code source file path",
+    "isTraversal": true
+  },
+  {
+    "input": "/code",
+    "path": "/code/test.txt",
+    "description": "Bare container code directory without trailing separator is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/code/",
+    "path": "/code/test.txt",
+    "description": "Bare container code directory with trailing separator is not traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/code/",
+    "path": "/code/",
+    "description": "Bare container code directory with trailing separator is not traversal by itself",
+    "isTraversal": false
+  },
+  {
+    "input": "/Applications/Zen.app",
+    "path": "/Applications/Zen.app",
+    "description": "MacOS Applications absolute path with uppercase root",
+    "isTraversal": true
+  },
+  {
+    "input": "/Users/user/",
+    "path": "/Users/user/test.txt",
+    "description": "MacOS Users directory input with file path",
+    "isTraversal": true
+  },
+  {
+    "input": "/Volumes/ExternalDrive/",
+    "path": "/Volumes/ExternalDrive/test.txt",
+    "description": "MacOS Volumes directory input with file path",
+    "isTraversal": true
+  },
+  {
+    "input": "/etc/./",
+    "path": "/etc/./passwd",
+    "description": "Current directory marker in Linux etc directory input",
+    "isTraversal": true
+  },
+  {
+    "input": "/etc/./passwd",
+    "path": "/etc/./passwd",
+    "description": "Current directory marker in Linux etc file path",
+    "isTraversal": true
+  },
+  {
+    "input": "/./etc/./passwd",
+    "path": "/./etc/./passwd",
+    "description": "Leading and nested current directory markers in Linux etc file path",
+    "isTraversal": true
+  },
+  {
+    "input": "/etc/././passwd",
+    "path": "/etc/././passwd",
+    "description": "Repeated current directory markers in Linux etc file path",
+    "isTraversal": true
+  },
+  {
+    "input": "///.///etc/passwd",
+    "path": "///.///etc/passwd",
+    "description": "Repeated slash and current directory prefix in Linux etc file path",
+    "isTraversal": true
+  },
+  {
+    "input": "//etc/passwd",
+    "path": "//etc/passwd",
+    "description": "Repeated slash Linux etc file path",
+    "isTraversal": true
+  },
+  {
+    "input": "//etc/some_directory",
+    "path": "//etc/some_directory",
+    "description": "Repeated slash Linux etc directory path",
     "isTraversal": true
   },
   {
@@ -381,6 +681,30 @@
     "input": "/Home/StatusCode/404",
     "path": "/home/site/wwwroot/Home/StatusCode/404",
     "description": "URL route under Linux home app root is not absolute path traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/home/statuscode/404",
+    "path": "/home/site/wwwroot/home/statuscode/404",
+    "description": "Lowercase URL route under Linux home app root is not absolute path traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/tmp/status.txt",
+    "path": "/home/site/wwwroot/tmp/status.txt",
+    "description": "URL route named like Linux tmp root under app root is not absolute path traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/var/log/health",
+    "path": "/home/site/wwwroot/var/log/health",
+    "description": "URL route named like Linux var log path under app root is not absolute path traversal",
+    "isTraversal": false
+  },
+  {
+    "input": "/Users/Profile/42",
+    "path": "/home/site/wwwroot/Users/Profile/42",
+    "description": "URL route named like users root under app root is not absolute path traversal",
     "isTraversal": false
   }
 ]

--- a/e2e/sample-apps/UmbracoSampleApp/AppBuilderHelper.cs
+++ b/e2e/sample-apps/UmbracoSampleApp/AppBuilderHelper.cs
@@ -73,6 +73,8 @@ namespace UmbracoSampleApp
                     u.UseWebsiteEndpoints();
                     var petsController = new PetsController(app.Services);
                     petsController.ConfigureEndpoints(u.EndpointRouteBuilder);
+                    var pathTraversalController = new PathTraversalController();
+                    pathTraversalController.ConfigureEndpoints(u.EndpointRouteBuilder);
                 });
 
             return app;

--- a/e2e/sample-apps/UmbracoSampleApp/Controllers/PathTraversalController.cs
+++ b/e2e/sample-apps/UmbracoSampleApp/Controllers/PathTraversalController.cs
@@ -1,0 +1,69 @@
+using Aikido.Zen.Core.Exceptions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace UmbracoSampleApp.Controllers
+{
+    public class PathTraversalController
+    {
+        public virtual void ConfigureEndpoints(IEndpointRouteBuilder endpoints)
+        {
+            endpoints.MapGet("/api/path-traversal", (HttpContext httpContext) =>
+            {
+                var filePath = httpContext.Request.Query.TryGetValue("path", out var pathValues) ? pathValues.FirstOrDefault() : null;
+
+                if (string.IsNullOrEmpty(filePath))
+                {
+                    return Results.BadRequest("Path parameter is required");
+                }
+
+                try
+                {
+                    filePath = Uri.UnescapeDataString(filePath);
+                    var fullPath = GetTestFilePath(filePath);
+                    return ReadFile(httpContext, filePath, fullPath);
+                }
+                catch (AikidoException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    return Results.BadRequest($"Error reading file: {ex.Message}");
+                }
+            });
+        }
+
+        private static string GetTestFilePath(string filePath)
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "aikido-test");
+            Directory.CreateDirectory(tempDir);
+
+            var secretFile = Path.Combine(tempDir, "secret.txt");
+            var safeFile = Path.Combine(tempDir, "safe.txt");
+            var anotherSafeFile = Path.Combine(tempDir, "another-safe.txt");
+            var thirdSafeFile = Path.Combine(tempDir, "third-safe.txt");
+
+            File.WriteAllText(secretFile, "This is a secret file that should not be accessible!");
+            File.WriteAllText(safeFile, "This is a safe file.");
+            File.WriteAllText(anotherSafeFile, "This is another safe file.");
+            File.WriteAllText(thirdSafeFile, "This is a third safe file.");
+
+            return tempDir + Path.DirectorySeparatorChar + filePath;
+        }
+
+        private static IResult ReadFile(HttpContext httpContext, string requestedPath, string fullPath)
+        {
+            var content = File.ReadAllText(fullPath);
+
+            return Results.Ok(new
+            {
+                content = content,
+                requestedPath = requestedPath,
+                resolvedPath = fullPath,
+                allFlattenedParams = httpContext.Request.Query.ToDictionary(query => query.Key, query => query.Value.FirstOrDefault())
+            });
+        }
+    }
+}


### PR DESCRIPTION
Adds coverage that routes encoded query input through HttpHelper, uses the generated decoded ParsedUserInput entry, and verifies PathTraversalHelper detects the traversal without detector-level URL decoding.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Improved path traversal detection by adding StartsWithUnsafePath check

**🔧 Refactors**
* Refactored DetectPathTraversal to use normalized spans and early returns


<sup>[More info](https://app.aikido.dev/featurebranch/scan/121656669?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->