### PR TITLE
Properly dispose API calls during shutdown

### DIFF
--- a/Aikido.Zen.Core/Agent.cs
+++ b/Aikido.Zen.Core/Agent.cs
@@ -118,12 +118,9 @@ namespace Aikido.Zen.Core
                 if (response.Success)
                 {
                     var reportingResponse = response as ReportingAPIResponse;
-                    Task.Run(() => UpdateConfig(reportingResponse));
+                    UpdateConfig(reportingResponse).GetAwaiter().GetResult();
                 }
             });
-
-            // get blocked ip list and add to context
-            Task.Run(async () => await UpdateFirewallLists()).GetAwaiter().GetResult();
 
             // Schedule heartbeat event every x minutes
             var scheduledHeartBeat = new ScheduledItem
@@ -250,7 +247,7 @@ namespace Aikido.Zen.Core
                     {
                         try
                         {
-                            var response = _api.Reporting.ReportAsync(eventItem.Token, eventItem.Event)
+                            var response = _api.Reporting.ReportAsync(eventItem.Token, eventItem.Event, CancellationToken.None)
                                 .ConfigureAwait(false)
                                 .GetAwaiter()
                                 .GetResult();
@@ -562,7 +559,7 @@ namespace Aikido.Zen.Core
             {
                 requestsThisSecond++;
                 LogHelper.DebugLog(Logger, $"Sending event: {queuedItem.Event.Type}");
-                var response = await _api.Reporting.ReportAsync(queuedItem.Token, queuedItem.Event)
+                var response = await _api.Reporting.ReportAsync(queuedItem.Token, queuedItem.Event, _cancellationSource.Token)
                     .ConfigureAwait(false);
 
                 _reportingStatus.OnEventReported(queuedItem.Event.Type, response.Success);
@@ -601,7 +598,7 @@ namespace Aikido.Zen.Core
         internal bool ConfigChanged(out ReportingAPIResponse latestConfig)
         {
             // Check if new configuration available
-            var latestConfigVersion = _api.Runtime.GetConfigLastUpdated(EnvironmentHelper.Token).Result;
+            var latestConfigVersion = _api.Runtime.GetConfigLastUpdated(EnvironmentHelper.Token, _cancellationSource.Token).Result;
 
             if (!latestConfigVersion.Success)
             {
@@ -618,7 +615,7 @@ namespace Aikido.Zen.Core
             }
 
             // Retrieve new configuration
-            latestConfig = _api.Runtime.GetConfig(EnvironmentHelper.Token).Result;
+            latestConfig = _api.Runtime.GetConfig(EnvironmentHelper.Token, _cancellationSource.Token).Result;
 
             // Trigger config change if new configuration retrieved successfully
             return latestConfig.Success;
@@ -634,7 +631,7 @@ namespace Aikido.Zen.Core
         {
             if (string.IsNullOrEmpty(EnvironmentHelper.Token))
                 return;
-            var firewallListsResponse = await _api.Reporting.GetFirewallLists(EnvironmentHelper.Token);
+            var firewallListsResponse = await _api.Reporting.GetFirewallLists(EnvironmentHelper.Token, _cancellationSource.Token);
             if (firewallListsResponse.Success)
             {
                 _context.UpdateFirewallLists(firewallListsResponse);

--- a/Aikido.Zen.Core/Api/IReporting.cs
+++ b/Aikido.Zen.Core/Api/IReporting.cs
@@ -1,11 +1,11 @@
-using Aikido.Zen.Core.Api;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Aikido.Zen.Core.Api
 {
     internal interface IReportingAPIClient
     {
-        Task<ReportingAPIResponse> ReportAsync(string token, object @event);
-        Task<FirewallListsAPIResponse> GetFirewallLists(string token);
+        Task<ReportingAPIResponse> ReportAsync(string token, object @event, CancellationToken cancellationToken);
+        Task<FirewallListsAPIResponse> GetFirewallLists(string token, CancellationToken cancellationToken);
     }
 }

--- a/Aikido.Zen.Core/Api/IRuntime.cs
+++ b/Aikido.Zen.Core/Api/IRuntime.cs
@@ -1,10 +1,11 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Aikido.Zen.Core.Api
 {
     internal interface IRuntimeAPIClient
     {
-        Task<ConfigLastUpdatedAPIResponse> GetConfigLastUpdated(string token);
-        Task<ReportingAPIResponse> GetConfig(string token);
+        Task<ConfigLastUpdatedAPIResponse> GetConfigLastUpdated(string token, CancellationToken cancellationToken);
+        Task<ReportingAPIResponse> GetConfig(string token, CancellationToken cancellationToken);
     }
 }

--- a/Aikido.Zen.Core/Api/Reporting.cs
+++ b/Aikido.Zen.Core/Api/Reporting.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Aikido.Zen.Core.Helpers;
 
@@ -16,7 +17,7 @@ namespace Aikido.Zen.Core.Api
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         }
 
-        public async Task<ReportingAPIResponse> ReportAsync(string token, object @event)
+        public async Task<ReportingAPIResponse> ReportAsync(string token, object @event, CancellationToken cancellationToken)
         {
             try
             {
@@ -24,7 +25,7 @@ namespace Aikido.Zen.Core.Api
                 var eventAsJson = JsonSerializer.Serialize(@event, ZenApi.JsonSerializerOptions);
                 var requestContent = new StringContent(eventAsJson, Encoding.UTF8, "application/json");
                 var request = APIHelper.CreateRequest(token, new Uri(EnvironmentHelper.AikidoUrl), "api/runtime/events", HttpMethod.Post, requestContent);
-                var response = await _httpClient.SendAsync(request);
+                var response = await _httpClient.SendAsync(request, cancellationToken);
                 return APIHelper.ToAPIResponse<ReportingAPIResponse>(response);
             }
             catch (TaskCanceledException ex)
@@ -39,12 +40,12 @@ namespace Aikido.Zen.Core.Api
             }
         }
 
-        public async Task<FirewallListsAPIResponse> GetFirewallLists(string token)
+        public async Task<FirewallListsAPIResponse> GetFirewallLists(string token, CancellationToken cancellationToken)
         {
             try
             {
                 var request = APIHelper.CreateRequest(token, new Uri(EnvironmentHelper.AikidoUrl), "api/runtime/firewall/lists", HttpMethod.Get);
-                var response = await _httpClient.SendAsync(request);
+                var response = await _httpClient.SendAsync(request, cancellationToken);
                 return APIHelper.ToAPIResponse<FirewallListsAPIResponse>(response);
             }
             catch (TaskCanceledException ex)

--- a/Aikido.Zen.Core/Api/Runtime.cs
+++ b/Aikido.Zen.Core/Api/Runtime.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Aikido.Zen.Core.Helpers;
 
@@ -14,13 +15,12 @@ namespace Aikido.Zen.Core.Api
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         }
 
-
-        public async Task<ConfigLastUpdatedAPIResponse> GetConfigLastUpdated(string token)
+        public async Task<ConfigLastUpdatedAPIResponse> GetConfigLastUpdated(string token, CancellationToken cancellationToken)
         {
             try
             {
                 var request = APIHelper.CreateRequest(token, new Uri(EnvironmentHelper.AikidoRealtimeUrl), "config", HttpMethod.Get);
-                var response = await _httpClient.SendAsync(request);
+                var response = await _httpClient.SendAsync(request, cancellationToken);
                 return APIHelper.ToAPIResponse<ConfigLastUpdatedAPIResponse>(response);
             }
             catch (TaskCanceledException ex)
@@ -35,12 +35,12 @@ namespace Aikido.Zen.Core.Api
             }
         }
 
-        public async Task<ReportingAPIResponse> GetConfig(string token)
+        public async Task<ReportingAPIResponse> GetConfig(string token, CancellationToken cancellationToken)
         {
             try
             {
                 var request = APIHelper.CreateRequest(token, new Uri(EnvironmentHelper.AikidoUrl), "/api/runtime/config", HttpMethod.Get);
-                var response = await _httpClient.SendAsync(request);
+                var response = await _httpClient.SendAsync(request, cancellationToken);
                 return APIHelper.ToAPIResponse<ReportingAPIResponse>(response);
             }
             catch (TaskCanceledException ex)

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -267,6 +267,47 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
+        public async Task Start_AppliesFirewallListsFromStartupConfig()
+        {
+            var blockedIpList = new FirewallListsAPIResponse.IPList
+            {
+                Key = "known_threat_actors/public_scanners",
+                Ips = new[] { "203.0.113.10" }
+            };
+            var reportingApiMock = new Mock<IReportingAPIClient>();
+            reportingApiMock
+                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ReportingAPIResponse { Success = true });
+            reportingApiMock
+                .Setup(r => r.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new FirewallListsAPIResponse
+                {
+                    Success = true,
+                    BlockedIPAddresses = new[] { blockedIpList }
+                });
+
+            _zenApiMock = ZenApiMock.CreateMock(reporting: reportingApiMock.Object);
+            _agent = new Agent(_zenApiMock.Object);
+
+            _agent.Start();
+
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (!_agent.Context.Config.GetMatchingBlockedIPListKeys("203.0.113.10").Any() && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(25);
+            }
+
+            Assert.That(
+                _agent.Context.Config.GetMatchingBlockedIPListKeys("203.0.113.10"),
+                Is.EquivalentTo(new[] { "known_threat_actors/public_scanners" })
+            );
+            reportingApiMock.Verify(
+                r => r.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Once
+            );
+        }
+
+        [Test]
         public async Task Dispose_CancelsStartupConfigUpdate()
         {
             var startupConfigEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -126,7 +126,8 @@ namespace Aikido.Zen.Test
             _zenApiMock.Verify(
                 r => r.Reporting.ReportAsync(
                     token,
-                    It.Is<Started>(e => e.GetType() == typeof(Started))
+                    It.Is<Started>(e => e.GetType() == typeof(Started)),
+                    It.IsAny<CancellationToken>()
                 ),
                 Times.AtLeastOnce()
             );
@@ -258,10 +259,46 @@ namespace Aikido.Zen.Test
             _zenApiMock.Verify(
                 r => r.Reporting.ReportAsync(
                     It.IsAny<string>(),
-                    It.Is<Started>(s => s.GetType() == typeof(Started))
+                    It.Is<Started>(s => s.GetType() == typeof(Started)),
+                    It.IsAny<CancellationToken>()
                 ),
                 Times.Once
             );
+        }
+
+        [Test]
+        public async Task Dispose_CancelsStartupConfigUpdate()
+        {
+            var startupConfigEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var startupConfigCanceled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var reportingApiMock = new Mock<IReportingAPIClient>();
+            reportingApiMock
+                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ReportingAPIResponse { Success = true, Block = false });
+            reportingApiMock
+                .Setup(r => r.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns<string, CancellationToken>((_, cancellationToken) =>
+                {
+                    startupConfigEntered.SetResult(true);
+                    var response = new TaskCompletionSource<FirewallListsAPIResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    cancellationToken.Register(() =>
+                    {
+                        startupConfigCanceled.TrySetResult(true);
+                        response.TrySetResult(new FirewallListsAPIResponse { Success = false, Error = "cancelled" });
+                    });
+                    return response.Task;
+                });
+
+            _zenApiMock = ZenApiMock.CreateMock(reporting: reportingApiMock.Object);
+            _agent = new Agent(_zenApiMock.Object);
+
+            _agent.Start();
+            await startupConfigEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var disposeTask = Task.Run(() => _agent.Dispose());
+            await startupConfigCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
         }
 
         [Test]
@@ -328,7 +365,8 @@ namespace Aikido.Zen.Test
             _zenApiMock.Verify(
                 r => r.Reporting.ReportAsync(
                     "token",
-                    It.Is<Started>(e => e == testEvent)
+                    It.Is<Started>(e => e == testEvent),
+                    It.IsAny<CancellationToken>()
                 ),
                 Times.Once
             );
@@ -383,7 +421,8 @@ namespace Aikido.Zen.Test
             _zenApiMock.Verify(
                 r => r.Reporting.ReportAsync(
                     "token",
-                    It.IsAny<Started>()
+                    It.IsAny<Started>(),
+                    It.IsAny<CancellationToken>()
                 ),
                 Times.AtLeast(2)
             );
@@ -420,7 +459,8 @@ namespace Aikido.Zen.Test
             _zenApiMock.Verify(
                 r => r.Reporting.ReportAsync(
                     "token",
-                    It.IsAny<Started>()
+                    It.IsAny<Started>(),
+                    It.IsAny<CancellationToken>()
                 ),
                 Times.AtMost(2)
             );
@@ -551,7 +591,8 @@ namespace Aikido.Zen.Test
                         a.Request.Headers.ContainsKey("Content-Type") &&
                         a.Attack.Metadata.ContainsKey("sql")
 
-                    )
+                    ),
+                    It.IsAny<CancellationToken>()
                 ),
                 Times.Once
             );
@@ -640,7 +681,7 @@ namespace Aikido.Zen.Test
 
             // Assert - verify no more events processed after dispose
             _zenApiMock.Verify(
-                r => r.Reporting.ReportAsync(It.IsAny<string>(), It.IsAny<IEvent>()),
+                r => r.Reporting.ReportAsync(It.IsAny<string>(), It.IsAny<IEvent>(), It.IsAny<CancellationToken>()),
                 Times.Once // Only the first event before dispose
             );
         }
@@ -751,9 +792,9 @@ namespace Aikido.Zen.Test
             };
 
             var runtimeApiClientMock = new Mock<IRuntimeAPIClient>();
-            runtimeApiClientMock.Setup(x => x.GetConfigLastUpdated(It.IsAny<string>()))
+            runtimeApiClientMock.Setup(x => x.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(configVersionResponse);
-            runtimeApiClientMock.Setup(x => x.GetConfig(It.IsAny<string>()))
+            runtimeApiClientMock.Setup(x => x.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(configResponse);
             _zenApiMock = ZenApiMock.CreateMock(runtime: runtimeApiClientMock.Object);
             _agent = new Agent(_zenApiMock.Object);
@@ -772,8 +813,8 @@ namespace Aikido.Zen.Test
                 Assert.That(response.Endpoints, Is.EquivalentTo(endpoints));
             });
 
-            _zenApiMock.Verify(x => x.Runtime.GetConfigLastUpdated(It.IsAny<string>()), Times.Once);
-            _zenApiMock.Verify(x => x.Runtime.GetConfig(It.IsAny<string>()), Times.Once);
+            _zenApiMock.Verify(x => x.Runtime.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            _zenApiMock.Verify(x => x.Runtime.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]
@@ -793,9 +834,9 @@ namespace Aikido.Zen.Test
                 ConfigUpdatedAt = configLastUpdated,
             };
             var runtimeApiClientMock = new Mock<IRuntimeAPIClient>();
-            runtimeApiClientMock.Setup(x => x.GetConfigLastUpdated(It.IsAny<string>()))
+            runtimeApiClientMock.Setup(x => x.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(configVersionResponse);
-            runtimeApiClientMock.Setup(x => x.GetConfig(It.IsAny<string>()))
+            runtimeApiClientMock.Setup(x => x.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(configResponse);
             _zenApiMock = ZenApiMock.CreateMock(runtime: runtimeApiClientMock.Object);
             _agent = new Agent(_zenApiMock.Object);
@@ -813,8 +854,8 @@ namespace Aikido.Zen.Test
                 Assert.That(response.ConfigUpdatedAt, Is.EqualTo(configLastUpdated));
             });
 
-            _zenApiMock.Verify(x => x.Runtime.GetConfigLastUpdated(It.IsAny<string>()), Times.Once);
-            _zenApiMock.Verify(x => x.Runtime.GetConfig(It.IsAny<string>()), Times.Never);
+            _zenApiMock.Verify(x => x.Runtime.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            _zenApiMock.Verify(x => x.Runtime.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Test]
@@ -837,9 +878,9 @@ namespace Aikido.Zen.Test
             };
 
             var runtimeApiClientMock = new Mock<IRuntimeAPIClient>();
-            runtimeApiClientMock.Setup(x => x.GetConfigLastUpdated(It.IsAny<string>()))
+            runtimeApiClientMock.Setup(x => x.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(configVersionResponse);
-            runtimeApiClientMock.Setup(x => x.GetConfig(It.IsAny<string>()))
+            runtimeApiClientMock.Setup(x => x.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(failedConfigResponse);
             _zenApiMock = ZenApiMock.CreateMock(runtime: runtimeApiClientMock.Object);
             _agent = new Agent(_zenApiMock.Object);
@@ -857,8 +898,8 @@ namespace Aikido.Zen.Test
                 Assert.That(_agent.Context.Config.ConfigLastUpdated, Is.EqualTo(configLastUpdated));
             });
 
-            _zenApiMock.Verify(x => x.Runtime.GetConfigLastUpdated(It.IsAny<string>()), Times.Once);
-            _zenApiMock.Verify(x => x.Runtime.GetConfig(It.IsAny<string>()), Times.Once);
+            _zenApiMock.Verify(x => x.Runtime.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            _zenApiMock.Verify(x => x.Runtime.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]
@@ -871,7 +912,7 @@ namespace Aikido.Zen.Test
             await _agent.UpdateFirewallLists();
 
             // Assert
-            _zenApiMock.Verify(x => x.Reporting.GetFirewallLists(It.IsAny<string>()), Times.Never);
+            _zenApiMock.Verify(x => x.Reporting.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Test]

--- a/Aikido.Zen.Test/OutboundRequestSinkTests.cs
+++ b/Aikido.Zen.Test/OutboundRequestSinkTests.cs
@@ -31,18 +31,18 @@ namespace Aikido.Zen.Test
 
             _reportingApiMock = new Mock<IReportingAPIClient>();
             _reportingApiMock
-                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>()))
+                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ReportingAPIResponse { Success = true });
             _reportingApiMock
-                .Setup(r => r.GetFirewallLists(It.IsAny<string>()))
+                .Setup(r => r.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new FirewallListsAPIResponse { Success = true });
 
             _runtimeApiMock = new Mock<IRuntimeAPIClient>();
             _runtimeApiMock
-                .Setup(r => r.GetConfig(It.IsAny<string>()))
+                .Setup(r => r.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ReportingAPIResponse { Success = true });
             _runtimeApiMock
-                .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>()))
+                .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ConfigLastUpdatedAPIResponse { Success = true });
 
             _agent = Agent.NewInstance(ZenApiMock.CreateMock(_reportingApiMock.Object, _runtimeApiMock.Object).Object);

--- a/Aikido.Zen.Test/PathTraversalHelperTests.cs
+++ b/Aikido.Zen.Test/PathTraversalHelperTests.cs
@@ -126,18 +126,18 @@ namespace Aikido.Zen.Test.Helpers
         {
             var reportingApiMock = new Mock<IReportingAPIClient>();
             reportingApiMock
-                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>()))
+                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ReportingAPIResponse { Success = true });
             reportingApiMock
-                .Setup(r => r.GetFirewallLists(It.IsAny<string>()))
+                .Setup(r => r.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new FirewallListsAPIResponse { Success = true });
 
             var runtimeApiMock = new Mock<IRuntimeAPIClient>();
             runtimeApiMock
-                .Setup(r => r.GetConfig(It.IsAny<string>()))
+                .Setup(r => r.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ReportingAPIResponse { Success = true });
             runtimeApiMock
-                .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>()))
+                .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ConfigLastUpdatedAPIResponse { Success = true });
 
             Agent.NewInstance(ZenApiMock.CreateMock(reportingApiMock.Object, runtimeApiMock.Object).Object);
@@ -159,7 +159,8 @@ namespace Aikido.Zen.Test.Helpers
                         a.Attack.Path == ".file" &&
                         a.Attack.Metadata.ContainsKey("filename") &&
                         (string)a.Attack.Metadata["filename"] == filename &&
-                        !a.Attack.Metadata.ContainsKey("path"))),
+                        !a.Attack.Metadata.ContainsKey("path")),
+                    It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 

--- a/Aikido.Zen.Test/ProcessExecutionSinkTests.cs
+++ b/Aikido.Zen.Test/ProcessExecutionSinkTests.cs
@@ -32,11 +32,11 @@ namespace Aikido.Zen.Test
             Environment.SetEnvironmentVariable("AIKIDO_TOKEN", "test-token");
             var reportingMock = new Mock<IReportingAPIClient>();
             reportingMock
-                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<IEvent>()))
+                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<IEvent>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(new ReportingAPIResponse { Success = true });
             var runtimeMock = new Mock<IRuntimeAPIClient>();
             runtimeMock
-                .Setup(r => r.GetConfig(It.IsAny<string>()))
+                .Setup(r => r.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ReportingAPIResponse { Success = true });
             var zenApiMock = new ZenApi(reportingMock.Object, runtimeMock.Object);
 

--- a/Aikido.Zen.Test/ReportingAPIClientTests.cs
+++ b/Aikido.Zen.Test/ReportingAPIClientTests.cs
@@ -46,7 +46,7 @@ namespace Aikido.Zen.Test
                 .ReturnsAsync(response);
 
             // Act
-            var result = await _reportingApiClient.ReportAsync("token", new { });
+            var result = await _reportingApiClient.ReportAsync("token", new { }, CancellationToken.None);
 
             // Assert
             Assert.That(result.Success);
@@ -74,7 +74,7 @@ namespace Aikido.Zen.Test
                 .ThrowsAsync(new Exception("An error occurred while reporting"));
 
             // Act & Assert
-            Assert.DoesNotThrowAsync(async () => await _reportingApiClient.ReportAsync("token", new { }));
+            Assert.DoesNotThrowAsync(async () => await _reportingApiClient.ReportAsync("token", new { }, CancellationToken.None));
         }
         [Test]
         public async Task ReportAsync_ShouldContinueOnTimeoutTaskCanceledException()
@@ -93,7 +93,7 @@ namespace Aikido.Zen.Test
 
             // Act
 
-            Assert.DoesNotThrowAsync(async () => result = await _reportingApiClient.ReportAsync("token", new { }), "Failed: Task timed out, but the exception propagated.");
+            Assert.DoesNotThrowAsync(async () => result = await _reportingApiClient.ReportAsync("token", new { }, CancellationToken.None), "Failed: Task timed out, but the exception propagated.");
 
             // Assert
             Assert.That(result!.Success, Is.False);
@@ -120,7 +120,7 @@ namespace Aikido.Zen.Test
                 .ReturnsAsync(response);
 
             // Act
-            var result = await _reportingApiClient.GetFirewallLists("token");
+            var result = await _reportingApiClient.GetFirewallLists("token", CancellationToken.None);
             await Task.Delay(100);
 
             // Assert
@@ -149,7 +149,7 @@ namespace Aikido.Zen.Test
                 .ThrowsAsync(new Exception("An error occurred while getting blocked IPs"));
 
             // Act & Assert
-            Assert.DoesNotThrowAsync(async () => await _reportingApiClient.GetFirewallLists("token"));
+            Assert.DoesNotThrowAsync(async () => await _reportingApiClient.GetFirewallLists("token", CancellationToken.None));
         }
         [Test]
         public async Task GetFirewallLists_ShouldContinueOnTimeoutTaskCanceledException()
@@ -168,7 +168,7 @@ namespace Aikido.Zen.Test
 
             // Act
 
-            Assert.DoesNotThrowAsync(async () => result = await _reportingApiClient.GetFirewallLists("token"), "Failed: Task timed out, but the exception propagated.");
+            Assert.DoesNotThrowAsync(async () => result = await _reportingApiClient.GetFirewallLists("token", CancellationToken.None), "Failed: Task timed out, but the exception propagated.");
 
             // Assert
             Assert.That(result!.Success, Is.False);

--- a/Aikido.Zen.Test/RuntimeApiClientTests.cs
+++ b/Aikido.Zen.Test/RuntimeApiClientTests.cs
@@ -44,7 +44,7 @@ namespace Aikido.Zen.Test
                 .ReturnsAsync(response);
 
             // Act
-            var result = await _runtimeApiClient.GetConfigLastUpdated("token");
+            var result = await _runtimeApiClient.GetConfigLastUpdated("token", CancellationToken.None);
             await Task.Delay(100);
 
             // Assert
@@ -73,7 +73,7 @@ namespace Aikido.Zen.Test
                 .ThrowsAsync(new Exception("An error occurred while getting config version"));
 
             // Act & Assert
-            Assert.DoesNotThrowAsync(async () => await _runtimeApiClient.GetConfigLastUpdated("token"));
+            Assert.DoesNotThrowAsync(async () => await _runtimeApiClient.GetConfigLastUpdated("token", CancellationToken.None));
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace Aikido.Zen.Test
 
             // Act
 
-            Assert.DoesNotThrowAsync(async () => result = await _runtimeApiClient.GetConfigLastUpdated("token"), "Failed: Task timed out, but the exception propagated.");
+            Assert.DoesNotThrowAsync(async () => result = await _runtimeApiClient.GetConfigLastUpdated("token", CancellationToken.None), "Failed: Task timed out, but the exception propagated.");
 
             // Assert
             Assert.That(result!.Success, Is.False);
@@ -120,7 +120,7 @@ namespace Aikido.Zen.Test
                 .ReturnsAsync(response);
 
             // Act
-            var result = await _runtimeApiClient.GetConfig("token");
+            var result = await _runtimeApiClient.GetConfig("token", CancellationToken.None);
             await Task.Delay(100);
 
             // Assert
@@ -151,7 +151,7 @@ namespace Aikido.Zen.Test
             ReportingAPIResponse result = new();
 
             // Act
-            Assert.DoesNotThrowAsync(async () => result = await _runtimeApiClient.GetConfig("token"));
+            Assert.DoesNotThrowAsync(async () => result = await _runtimeApiClient.GetConfig("token", CancellationToken.None));
 
             // Assert
             Assert.That(result.Success, Is.False);
@@ -174,7 +174,7 @@ namespace Aikido.Zen.Test
             ReportingAPIResponse result = new();
 
             // Act
-            Assert.DoesNotThrowAsync(async () => result = await _runtimeApiClient.GetConfig("token"));
+            Assert.DoesNotThrowAsync(async () => result = await _runtimeApiClient.GetConfig("token", CancellationToken.None));
 
             // Assert
             Assert.That(result.Success, Is.False);

--- a/Aikido.Zen.Test/SqlClientSinkTests.cs
+++ b/Aikido.Zen.Test/SqlClientSinkTests.cs
@@ -31,11 +31,11 @@ namespace Aikido.Zen.Test
             Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "true");
             var reportingMock = new Mock<IReportingAPIClient>();
             reportingMock
-                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<IEvent>()))
+                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<IEvent>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(new ReportingAPIResponse { Success = true });
             var runtimeMock = new Mock<IRuntimeAPIClient>();
             runtimeMock
-                .Setup(r => r.GetConfig(It.IsAny<string>()))
+                .Setup(r => r.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ReportingAPIResponse { Success = true });
             var zenApiMock = new ZenApi(reportingMock.Object, runtimeMock.Object);
 

--- a/Aikido.Zen.Test/SqlCommandHelperTests.cs
+++ b/Aikido.Zen.Test/SqlCommandHelperTests.cs
@@ -90,18 +90,18 @@ namespace Aikido.Zen.Test.Helpers
         {
             var reportingApiMock = new Mock<IReportingAPIClient>();
             reportingApiMock
-                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>()))
+                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ReportingAPIResponse { Success = true });
             reportingApiMock
-                .Setup(r => r.GetFirewallLists(It.IsAny<string>()))
+                .Setup(r => r.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new FirewallListsAPIResponse { Success = true });
 
             var runtimeApiMock = new Mock<IRuntimeAPIClient>();
             runtimeApiMock
-                .Setup(r => r.GetConfig(It.IsAny<string>()))
+                .Setup(r => r.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ReportingAPIResponse { Success = true });
             runtimeApiMock
-                .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>()))
+                .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ConfigLastUpdatedAPIResponse { Success = true });
 
             Agent.NewInstance(ZenApiMock.CreateMock(reportingApiMock.Object, runtimeApiMock.Object).Object);
@@ -127,7 +127,8 @@ namespace Aikido.Zen.Test.Helpers
                         a.Attack.Path == ".injection" &&
                         a.Attack.Metadata.ContainsKey("sql") &&
                         a.Attack.Metadata.ContainsKey("dialect") &&
-                        (string)a.Attack.Metadata["dialect"] == "Microsoft SQL")),
+                        (string)a.Attack.Metadata["dialect"] == "Microsoft SQL"),
+                    It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -138,18 +139,18 @@ namespace Aikido.Zen.Test.Helpers
 
             var reportingApiMock = new Mock<IReportingAPIClient>();
             reportingApiMock
-                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>()))
+                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ReportingAPIResponse { Success = true });
             reportingApiMock
-                .Setup(r => r.GetFirewallLists(It.IsAny<string>()))
+                .Setup(r => r.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new FirewallListsAPIResponse { Success = true });
 
             var runtimeApiMock = new Mock<IRuntimeAPIClient>();
             runtimeApiMock
-                .Setup(r => r.GetConfig(It.IsAny<string>()))
+                .Setup(r => r.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ReportingAPIResponse { Success = true });
             runtimeApiMock
-                .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>()))
+                .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ConfigLastUpdatedAPIResponse { Success = true });
 
             Agent.NewInstance(ZenApiMock.CreateMock(reportingApiMock.Object, runtimeApiMock.Object).Object);
@@ -178,7 +179,8 @@ namespace Aikido.Zen.Test.Helpers
                         a.Attack.Metadata.ContainsKey("sql") &&
                         a.Attack.Metadata.ContainsKey("dialect") &&
                         a.Attack.Metadata.ContainsKey("failedToTokenize") &&
-                        (string)a.Attack.Metadata["failedToTokenize"] == "true")),
+                        (string)a.Attack.Metadata["failedToTokenize"] == "true"),
+                    It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 

--- a/Aikido.Zen.Test/ZenApiTests.cs
+++ b/Aikido.Zen.Test/ZenApiTests.cs
@@ -15,7 +15,7 @@ namespace Aikido.Zen.Test
             _zenApi = ZenApiMock.CreateMock().Object;
 
             // Act
-            var result = await _zenApi.Reporting.ReportAsync("token", new { });
+            var result = await _zenApi.Reporting.ReportAsync("token", new { }, CancellationToken.None);
 
             // Assert
             Assert.That(result.Success);
@@ -28,7 +28,7 @@ namespace Aikido.Zen.Test
             _zenApi = ZenApiMock.CreateMockWithExceptions().Object;
 
             // Act & Assert
-            Assert.ThrowsAsync<Exception>(async () => await _zenApi.Reporting.ReportAsync("token", new { }));
+            Assert.ThrowsAsync<Exception>(async () => await _zenApi.Reporting.ReportAsync("token", new { }, CancellationToken.None));
         }
 
         [Test]
@@ -38,10 +38,10 @@ namespace Aikido.Zen.Test
             _zenApi = ZenApiMock.CreateMockWithFailedResponses().Object;
 
             // Act
-            var reportResponse = await _zenApi.Reporting.ReportAsync("token", new { });
-            var firewallListsResponse = await _zenApi.Reporting.GetFirewallLists("token");
-            var configVersionResponse = await _zenApi.Runtime.GetConfigLastUpdated("token");
-            var configResponse = await _zenApi.Runtime.GetConfig("token");
+            var reportResponse = await _zenApi.Reporting.ReportAsync("token", new { }, CancellationToken.None);
+            var firewallListsResponse = await _zenApi.Reporting.GetFirewallLists("token", CancellationToken.None);
+            var configVersionResponse = await _zenApi.Runtime.GetConfigLastUpdated("token", CancellationToken.None);
+            var configResponse = await _zenApi.Runtime.GetConfig("token", CancellationToken.None);
 
             // Assert
             Assert.Multiple(() =>
@@ -60,7 +60,7 @@ namespace Aikido.Zen.Test
             _zenApi = ZenApiMock.CreateMock().Object;
 
             // Act
-            var result = await _zenApi.Runtime.GetConfigLastUpdated("token");
+            var result = await _zenApi.Runtime.GetConfigLastUpdated("token", CancellationToken.None);
 
             // Assert
             Assert.That(result.Success);
@@ -73,7 +73,7 @@ namespace Aikido.Zen.Test
             _zenApi = ZenApiMock.CreateMockWithExceptions().Object;
 
             // Act & Assert
-            Assert.ThrowsAsync<Exception>(async () => await _zenApi.Runtime.GetConfigLastUpdated("token"));
+            Assert.ThrowsAsync<Exception>(async () => await _zenApi.Runtime.GetConfigLastUpdated("token", CancellationToken.None));
         }
 
         [Test]
@@ -83,7 +83,7 @@ namespace Aikido.Zen.Test
             _zenApi = ZenApiMock.CreateMock().Object;
 
             // Act
-            var result = await _zenApi.Runtime.GetConfig("token");
+            var result = await _zenApi.Runtime.GetConfig("token", CancellationToken.None);
 
             // Assert
             Assert.That(result.Success);
@@ -96,7 +96,7 @@ namespace Aikido.Zen.Test
             _zenApi = ZenApiMock.CreateMockWithExceptions().Object;
 
             // Act & Assert
-            Assert.ThrowsAsync<Exception>(async () => await _zenApi.Runtime.GetConfig("token"));
+            Assert.ThrowsAsync<Exception>(async () => await _zenApi.Runtime.GetConfig("token", CancellationToken.None));
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace Aikido.Zen.Test
             _zenApi = ZenApiMock.CreateMock().Object;
 
             // Act
-            var result = await _zenApi.Reporting.GetFirewallLists("token");
+            var result = await _zenApi.Reporting.GetFirewallLists("token", CancellationToken.None);
 
             // Assert
             Assert.That(result.Success);
@@ -119,7 +119,7 @@ namespace Aikido.Zen.Test
             _zenApi = ZenApiMock.CreateMockWithExceptions().Object;
 
             // Act & Assert
-            Assert.ThrowsAsync<Exception>(async () => await _zenApi.Reporting.GetFirewallLists("token"));
+            Assert.ThrowsAsync<Exception>(async () => await _zenApi.Reporting.GetFirewallLists("token", CancellationToken.None));
         }
     }
 }

--- a/Aikido.Zen.Tests.Mocks/ZenApiMock.cs
+++ b/Aikido.Zen.Tests.Mocks/ZenApiMock.cs
@@ -1,5 +1,6 @@
 using Aikido.Zen.Core.Api;
 using Moq;
+using System.Threading;
 
 namespace Aikido.Zen.Tests.Mocks
 {
@@ -11,11 +12,11 @@ namespace Aikido.Zen.Tests.Mocks
             {
                 var reportingMock = new Mock<IReportingAPIClient>();
                 reportingMock
-                    .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>()))
+                    .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(new ReportingAPIResponse { Success = true });
 
                 reportingMock
-                    .Setup(r => r.GetFirewallLists(It.IsAny<string>()))
+                    .Setup(r => r.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(new FirewallListsAPIResponse { Success = true });
                 reporting = reportingMock.Object;
             }
@@ -25,11 +26,11 @@ namespace Aikido.Zen.Tests.Mocks
             {
                 var runtimeMock = new Mock<IRuntimeAPIClient>();
                 runtimeMock
-                    .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>()))
+                    .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ConfigLastUpdatedAPIResponse { Success = true });
 
                 runtimeMock
-                    .Setup(r => r.GetConfig(It.IsAny<string>()))
+                    .Setup(r => r.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ReportingAPIResponse { Success = true });
                 runtime = runtimeMock.Object;
             }
@@ -44,20 +45,20 @@ namespace Aikido.Zen.Tests.Mocks
         {
             var reportingApiClient = new Mock<IReportingAPIClient>();
             reportingApiClient
-                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>()))
+                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ReportingAPIResponse { Success = false, Error = "Test error" });
 
             reportingApiClient
-                .Setup(r => r.GetFirewallLists(It.IsAny<string>()))
+                .Setup(r => r.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new FirewallListsAPIResponse { Success = false, Error = "Test error" });
 
             var runtimeApiClient = new Mock<IRuntimeAPIClient>();
             runtimeApiClient
-                .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>()))
+                .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ConfigLastUpdatedAPIResponse { Success = false, Error = "Test error" });
 
             runtimeApiClient
-                .Setup(r => r.GetConfig(It.IsAny<string>()))
+                .Setup(r => r.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ReportingAPIResponse { Success = false, Error = "Test error" });
 
             var zenApi = new Mock<IZenApi>();
@@ -71,20 +72,20 @@ namespace Aikido.Zen.Tests.Mocks
         {
             var reportingApiClient = new Mock<IReportingAPIClient>();
             reportingApiClient
-                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>()))
+                .Setup(r => r.ReportAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                     .ThrowsAsync(new System.Exception("Test exception"));
 
             reportingApiClient
-                .Setup(r => r.GetFirewallLists(It.IsAny<string>()))
+                .Setup(r => r.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new System.Exception("Test exception"));
 
             var runtimeApiClient = new Mock<IRuntimeAPIClient>();
             runtimeApiClient
-                .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>()))
+                .Setup(r => r.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new System.Exception("Test exception"));
 
             runtimeApiClient
-                .Setup(r => r.GetConfig(It.IsAny<string>()))
+                .Setup(r => r.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new System.Exception("Test exception"));
 
             var zenApi = new Mock<IZenApi>();


### PR DESCRIPTION
- Startup UpdateConfig now runs inside the queued started-event callback instead of detached via Task.Run.
- UpdateConfig owns the firewall-list refresh, so the duplicate startup UpdateFirewallLists call is gone.
- Runtime/config/firewall-list/reporting API calls now receive the agent cancellation token, so background work can be canceled during shutdown instead of running detached after agent replacement.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Passed CancellationToken through runtime and reporting API calls.

**🔧 Refactors**
* Updated API client implementations to use SendAsync with cancellation tokens.
* Adjusted test mocks to expect CancellationToken parameters in API calls.
* Ran UpdateConfig inside started-event callback and removed duplicate firewall refresh.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/122718258?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->