### PR TITLE
Fix race condition when switching to a new instance

### DIFF
--- a/Aikido.Zen.Core/Agent.cs
+++ b/Aikido.Zen.Core/Agent.cs
@@ -45,6 +45,7 @@ namespace Aikido.Zen.Core
 
         // instance
         private static Agent _instance;
+        private static readonly object InstanceLock = new object();
 
         /// <summary>
         /// Configures a static logger for Agent.
@@ -60,23 +61,30 @@ namespace Aikido.Zen.Core
         {
             get
             {
-                if (_instance == null)
+                lock (InstanceLock)
                 {
-                    var reportingHttpClient = ApiClientHttpClientFactory.Create();
-                    var runtimeHttpClient = ApiClientHttpClientFactory.Create();
-                    _instance = NewInstance(new ZenApi(new ReportingAPIClient(reportingHttpClient), new RuntimeAPIClient(runtimeHttpClient)));
+                    if (_instance == null)
+                    {
+                        var reportingHttpClient = ApiClientHttpClientFactory.Create();
+                        var runtimeHttpClient = ApiClientHttpClientFactory.Create();
+                        _instance = new Agent(new ZenApi(new ReportingAPIClient(reportingHttpClient), new RuntimeAPIClient(runtimeHttpClient)));
+                    }
+
+                    return _instance;
                 }
-                return _instance;
             }
         }
 
         internal static Agent NewInstance(IZenApi api)
         {
-            var newInstance = new Agent(api);
-            var oldInstance = Interlocked.Exchange(ref _instance, newInstance);
-            // Stop previous background work like config polls
-            oldInstance?.Dispose();
-            return newInstance;
+            lock (InstanceLock)
+            {
+                // Stop previous background work like config polls before publishing
+                // the replacement instance.
+                _instance?.Dispose();
+                _instance = new Agent(api);
+                return _instance;
+            }
         }
 
         /// <summary>

--- a/Aikido.Zen.Core/Agent.cs
+++ b/Aikido.Zen.Core/Agent.cs
@@ -67,7 +67,7 @@ namespace Aikido.Zen.Core
                     {
                         var reportingHttpClient = ApiClientHttpClientFactory.Create();
                         var runtimeHttpClient = ApiClientHttpClientFactory.Create();
-                        _instance = new Agent(new ZenApi(new ReportingAPIClient(reportingHttpClient), new RuntimeAPIClient(runtimeHttpClient)));
+                        NewInstance(new ZenApi(new ReportingAPIClient(reportingHttpClient), new RuntimeAPIClient(runtimeHttpClient)));
                     }
 
                     return _instance;

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -245,6 +245,46 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
+        public void NewInstance_DisposesPreviousInstanceBeforePublishingReplacement()
+        {
+            var instanceField = typeof(Agent).GetField("_instance", BindingFlags.NonPublic | BindingFlags.Static);
+            var cancellationSourceField = typeof(Agent).GetField("_cancellationSource", BindingFlags.NonPublic | BindingFlags.Instance);
+            var backgroundTaskField = typeof(Agent).GetField("_backgroundTask", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(instanceField, Is.Not.Null);
+            Assert.That(cancellationSourceField, Is.Not.Null);
+            Assert.That(backgroundTaskField, Is.Not.Null);
+
+            var first = Agent.NewInstance(_zenApiMock.Object);
+            var firstCancellationSource = cancellationSourceField!.GetValue(first) as CancellationTokenSource;
+            var firstBackgroundTask = backgroundTaskField!.GetValue(first) as Task;
+            Assert.That(firstCancellationSource, Is.Not.Null);
+            Assert.That(firstBackgroundTask, Is.Not.Null);
+
+            firstCancellationSource!.Cancel();
+            Assert.That(firstBackgroundTask!.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            Agent? instanceSeenByOldCallback = null;
+            first.QueueEvent("test-token", Started.Create(), (_, _) =>
+            {
+                instanceSeenByOldCallback = Agent.Instance;
+            });
+
+            var second = Agent.NewInstance(ZenApiMock.CreateMock().Object);
+
+            try
+            {
+                Assert.That(instanceSeenByOldCallback, Is.SameAs(first));
+                Assert.That(Agent.Instance, Is.SameAs(second));
+            }
+            finally
+            {
+                second.Dispose();
+                instanceField!.SetValue(null, null);
+                _agent = new Agent(_zenApiMock.Object);
+            }
+        }
+
+        [Test]
         public async Task Start_QueuesStartedEventAndSchedulesHeartbeat()
         {
             // Arrange


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Added locking to Agent singleton to prevent race condition

**🔧 Refactors**
* Disposed previous instance before publishing replacement to avoid concurrency


<sup>[More info](https://app.aikido.dev/featurebranch/scan/123277359?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->