### PR TITLE
Trim user input before sending to DetectSQLInjection

### DIFF
--- a/Aikido.Zen.Core/Vulnerabilities/SQLInjectionDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/SQLInjectionDetector.cs
@@ -30,7 +30,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
         public static SQLInjectionDetectionResult DetectSQLInjection(string query, string userInput, SQLDialect dialect)
         {
             query = query?.ToLower();
-            userInput = userInput?.ToLower();
+            userInput = userInput?.ToLower()?.Trim();
             return ZenInternals.DetectSQLInjection(query, userInput, dialect.ToRustDialectInt());
         }
     }

--- a/Aikido.Zen.Core/Vulnerabilities/SQLInjectionDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/SQLInjectionDetector.cs
@@ -30,7 +30,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
         public static SQLInjectionDetectionResult DetectSQLInjection(string query, string userInput, SQLDialect dialect)
         {
             query = query?.ToLower();
-            userInput = userInput?.ToLower()?.Trim();
+            userInput = userInput?.ToLower().Trim();
             return ZenInternals.DetectSQLInjection(query, userInput, dialect.ToRustDialectInt());
         }
     }

--- a/Aikido.Zen.Test/SqlInjectionDetectorTests.cs
+++ b/Aikido.Zen.Test/SqlInjectionDetectorTests.cs
@@ -86,6 +86,19 @@ namespace Aikido.Zen.Test
             Assert.That(result, Is.EqualTo(SQLInjectionDetectionResult.FailedToTokenize));
         }
 
+        [Test]
+        public void IsSQLInjection_WithTrailingSpacesInUserInput_DetectsInjection()
+        {
+            // Attacker pads payload with trailing spaces; the trimmed payload must still be detected.
+            var result = SQLInjectionDetector.IsSQLInjection(
+                "INSERT INTO pets (name, owner) VALUES ('x', 'dummy'), ('injected', 'hacker'); --', 'owner')",
+                "x', 'dummy'), ('injected', 'hacker'); --    ",
+                SQLDialect.Generic
+            );
+
+            Assert.That(result, Is.True);
+        }
+
         public static IEnumerable<TestCaseData> GetTestData()
         {
             var jsonData = File.ReadAllText("testdata/data.SQLInjectionDetector.json");


### PR DESCRIPTION
Trims leading/trailing whitespace from user input before SQL injection detection, matching the fix applied to the Java firewall in AikidoSec/firewall-java#298.

**Problem**: An attacker can pad their payload with trailing whitespace (e.g. `"payload   "`). If the DB driver trims this before execution, the SQL query won't contain the padded input, causing `ShouldReturnEarly` to incorrectly return `true` via the `query.Contains(userInput)` check (missed detection).

**Fix**: Apply `.ToLower()?.Trim()` to the user input before detection.

See: https://github.com/AikidoSec/firewall-java/pull/298

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Trimmed user input before SQL injection detection to prevent misses


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124649848?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->