### PR TITLE
Make path traversal containment check case-insensitive

### DIFF
--- a/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
@@ -96,7 +96,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
             // return if path or input is null or empty
             if (string.IsNullOrEmpty(input) || string.IsNullOrEmpty(path))
                 return false;
-            // ignore if path does not contain user input (case-insensitive for case-insensitive filesystems)
+            // ignore if path does not contain user input (case-insensitive)
             if (path.IndexOf(input, StringComparison.OrdinalIgnoreCase) < 0)
                 return false;
             // ignore if input is larger than the path

--- a/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/PathTraversalDetector.cs
@@ -96,8 +96,8 @@ namespace Aikido.Zen.Core.Vulnerabilities
             // return if path or input is null or empty
             if (string.IsNullOrEmpty(input) || string.IsNullOrEmpty(path))
                 return false;
-            // ignore if path does not contain user input
-            if (!path.Contains(input))
+            // ignore if path does not contain user input (case-insensitive for case-insensitive filesystems)
+            if (path.IndexOf(input, StringComparison.OrdinalIgnoreCase) < 0)
                 return false;
             // ignore if input is larger than the path
             if (input.Length > path.Length)

--- a/Aikido.Zen.Test/testdata/data.PathTraversalDetector.json
+++ b/Aikido.Zen.Test/testdata/data.PathTraversalDetector.json
@@ -345,7 +345,7 @@
     "input": "c:\\windows\\system32\\cmd.exe",
     "path": "C:\\Windows\\System32\\cmd.exe",
     "description": "Windows drive absolute path with case mismatch",
-    "isTraversal": false
+    "isTraversal": true
   },
   {
     "input": "%WINDIR%\\system32\\notepad.exe",


### PR DESCRIPTION
Makes the user-input containment check in path traversal detection case-insensitive, matching the fix applied to the Node.js firewall in AikidoSec/firewall-node#1047.

**Problem**: On case-insensitive filesystems (macOS APFS, Windows NTFS), an attacker can submit a path like `/ETC/PASSWD` which resolves to `/etc/passwd`. The detection check `path.Contains(input)` was case-sensitive, so `/ETC/PASSWD` would not be found in `/etc/passwd` and traversal would go undetected.

**Fix**: Changed `path.Contains(input)` to `path.IndexOf(input, StringComparison.OrdinalIgnoreCase) >= 0` (compatible with .NET Framework 4.6.1+).

See: https://github.com/AikidoSec/firewall-node/pull/1047

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Made path containment check case-insensitive to handle filesystem casing

**📚 Documentation**
* Clarified path traversal containment comment for case-insensitive comparison


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124668797?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->