### PR TITLE
Trim trailing dot from trusted IMDS hostnames

### DIFF
--- a/Aikido.Zen.Core/Vulnerabilities/SSRFDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/SSRFDetector.cs
@@ -249,7 +249,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
 
         private static bool IsTrustedImdsHostname(string hostname)
         {
-            return TrustedImdsHostnames.Contains(hostname.Trim());
+            return TrustedImdsHostnames.Contains(hostname.Trim().TrimEnd('.'));
         }
 
         private static bool IsImdsIPAddress(string ipAddress)

--- a/Aikido.Zen.Core/Vulnerabilities/SSRFDetector.cs
+++ b/Aikido.Zen.Core/Vulnerabilities/SSRFDetector.cs
@@ -142,7 +142,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
                 return hostname;
             }
 
-            var normalizedHostname = hostname.Trim().TrimStart('[').TrimEnd(']').ToLowerInvariant();
+            var normalizedHostname = hostname.Trim().TrimEnd('.').TrimStart('[').TrimEnd(']').ToLowerInvariant();
             try
             {
                 return HostnameIdnMapping.GetAscii(normalizedHostname).ToLowerInvariant();
@@ -249,7 +249,7 @@ namespace Aikido.Zen.Core.Vulnerabilities
 
         private static bool IsTrustedImdsHostname(string hostname)
         {
-            return TrustedImdsHostnames.Contains(hostname.Trim().TrimEnd('.'));
+            return TrustedImdsHostnames.Contains(NormalizeHostname(hostname));
         }
 
         private static bool IsImdsIPAddress(string ipAddress)

--- a/Aikido.Zen.Test/SSRFDetectorTests.cs
+++ b/Aikido.Zen.Test/SSRFDetectorTests.cs
@@ -376,6 +376,8 @@ namespace Aikido.Zen.Test
         [TestCase("metadata.google.internal", "169.254.169.254", false)]
         [TestCase("metadata.goog", "169.254.169.254", false)]
         [TestCase("METADATA.GOOGLE.INTERNAL", "169.254.169.254", false)]
+        [TestCase("metadata.google.internal.", "169.254.169.254", false)]
+        [TestCase("metadata.goog.", "169.254.169.254", false)]
         [TestCase(null, "169.254.169.254", false)]
         [TestCase(" ", "169.254.169.254", false)]
         [TestCase("169.254.169.254", "169.254.169.254", false)]


### PR DESCRIPTION
## Summary

DNS resolvers sometimes return fully-qualified domain names with a trailing dot (e.g. `metadata.google.internal.`). The `IsTrustedImdsHostname` method called `hostname.Trim()` which strips whitespace but not trailing dots, so these hostnames were not matched and GCP IMDS requests could be incorrectly flagged as stored SSRF.

- Add `.TrimEnd('.')` after `Trim()` in `IsTrustedImdsHostname` (the `HashSet` already uses `OrdinalIgnoreCase` so case is handled)
- Add test cases for trailing-dot variants

This is the same fix already applied in firewall-go (PR #459). Ported to Python, Ruby, .NET, PHP, and Java.

## Test plan
- [ ] `dotnet test Aikido.Zen.Test/` passes

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Stripped trailing dots from normalized hostnames to fix matching


<sup>[More info](https://app.aikido.dev/featurebranch/scan/128323545?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->