### PR TITLE
Fix uninitialized config handling and config update race

### DIFF
--- a/Aikido.Zen.Benchmarks/AgentContextBenchmarks.cs
+++ b/Aikido.Zen.Benchmarks/AgentContextBenchmarks.cs
@@ -105,18 +105,18 @@ namespace Aikido.Zen.Benchmarks
         {
             var agentContext = new AgentContext();
 
-            agentContext.UpdateConfig(_configResponse);
-            agentContext.UpdateFirewallLists(_firewallListsResponse);
+            agentContext.Config.UpdateConfig(_configResponse);
+            agentContext.Config.UpdateFirewallLists(_firewallListsResponse);
 
-            return agentContext.Endpoints.Count();
+            return agentContext.Config.Endpoints.Count();
         }
 
         [Benchmark]
         public int CheckBlockedRequests()
         {
             var agentContext = new AgentContext();
-            agentContext.UpdateConfig(_configResponse);
-            agentContext.UpdateFirewallLists(_firewallListsResponse);
+            agentContext.Config.UpdateConfig(_configResponse);
+            agentContext.Config.UpdateFirewallLists(_firewallListsResponse);
 
             var blocked = 0;
             for (var i = 0; i < ItemCount; i++)

--- a/Aikido.Zen.Core/Agent.cs
+++ b/Aikido.Zen.Core/Agent.cs
@@ -125,7 +125,7 @@ namespace Aikido.Zen.Core
                 if (response.Success)
                 {
                     var reportingResponse = response as ReportingAPIResponse;
-                    UpdateServiceConfig(reportingResponse);
+                    UpdateConfig(reportingResponse);
                     UpdateFirewallLists().GetAwaiter().GetResult();
                 }
             });
@@ -450,7 +450,11 @@ namespace Aikido.Zen.Core
                     if (LastConfigCheck + TimeSpan.FromMinutes(1) < DateTime.UtcNow)
                     {
                         LastConfigCheck = DateTime.UtcNow;
-                        await UpdateConfigIfChanged();
+                        if (ConfigChanged(out var response))
+                        {
+                            UpdateConfig(response);
+                            await UpdateFirewallLists();
+                        }
                     }
 
                     await ProcessScheduledEvents();
@@ -591,10 +595,8 @@ namespace Aikido.Zen.Core
 
         internal void HandleHeartbeatResponse(APIResponse response)
         {
-            var reportingResponse = response as ReportingAPIResponse;
-            if (reportingResponse != null && reportingResponse.Success)
+            if (response.Success)
             {
-                UpdateServiceConfig(reportingResponse);
                 LogHelper.DebugLog(Logger, "Heartbeat was sent successfully");
             }
             else
@@ -629,16 +631,7 @@ namespace Aikido.Zen.Core
             return latestConfig.Success;
         }
 
-        private async Task UpdateConfigIfChanged()
-        {
-            if (ConfigChanged(out var response))
-            {
-                UpdateServiceConfig(response);
-                await UpdateFirewallLists();
-            }
-        }
-
-        private void UpdateServiceConfig(ReportingAPIResponse response)
+        private void UpdateConfig(ReportingAPIResponse response)
         {
             _context.Config.UpdateConfig(response);
         }

--- a/Aikido.Zen.Core/Agent.cs
+++ b/Aikido.Zen.Core/Agent.cs
@@ -446,7 +446,12 @@ namespace Aikido.Zen.Core
             {
                 try
                 {
-                    await CheckConfigUpdates();
+                    // check for config updates every minute
+                    if (LastConfigCheck + TimeSpan.FromMinutes(1) < DateTime.UtcNow)
+                    {
+                        LastConfigCheck = DateTime.UtcNow;
+                        await UpdateConfigIfChanged();
+                    }
 
                     await ProcessScheduledEvents();
                     // we rate limit ourselves to 10 requests per second to the Zen API
@@ -624,19 +629,13 @@ namespace Aikido.Zen.Core
             return latestConfig.Success;
         }
 
-        internal async Task CheckConfigUpdates()
+        private async Task UpdateConfigIfChanged()
         {
-            // check for config updates every minute
-            if (LastConfigCheck + TimeSpan.FromMinutes(1) >= DateTime.UtcNow)
-                return;
-
             if (ConfigChanged(out var response))
             {
                 UpdateServiceConfig(response);
                 await UpdateFirewallLists();
             }
-
-            LastConfigCheck = DateTime.UtcNow;
         }
 
         private void UpdateServiceConfig(ReportingAPIResponse response)

--- a/Aikido.Zen.Core/Agent.cs
+++ b/Aikido.Zen.Core/Agent.cs
@@ -136,18 +136,7 @@ namespace Aikido.Zen.Core
                 Token = EnvironmentHelper.Token,
                 EventFactory = ConstructHeartbeat,
                 Interval = Heartbeat.GetNextInterval(),
-                Callback = (evt, response) =>
-                {
-                    var reportingResponse = response as ReportingAPIResponse;
-                    if (reportingResponse != null && reportingResponse.Success)
-                    {
-                        LogHelper.DebugLog(Logger, "Heartbeat was sent successfully");
-                    }
-                    else
-                    {
-                        LogHelper.WarningLog(Logger, $"Heartbeat was not sent successfully: {response.Error}");
-                    }
-                }
+                Callback = (evt, response) => HandleHeartbeatResponse(response)
             };
             ScheduleEvent(
                 Heartbeat.ScheduleId,
@@ -593,6 +582,20 @@ namespace Aikido.Zen.Core
             ClearContext();
 
             return heartbeat;
+        }
+
+        internal void HandleHeartbeatResponse(APIResponse response)
+        {
+            var reportingResponse = response as ReportingAPIResponse;
+            if (reportingResponse != null && reportingResponse.Success)
+            {
+                UpdateServiceConfig(reportingResponse);
+                LogHelper.DebugLog(Logger, "Heartbeat was sent successfully");
+            }
+            else
+            {
+                LogHelper.WarningLog(Logger, $"Heartbeat was not sent successfully: {response.Error}");
+            }
         }
 
         internal bool ConfigChanged(out ReportingAPIResponse latestConfig)

--- a/Aikido.Zen.Core/Agent.cs
+++ b/Aikido.Zen.Core/Agent.cs
@@ -125,7 +125,8 @@ namespace Aikido.Zen.Core
                 if (response.Success)
                 {
                     var reportingResponse = response as ReportingAPIResponse;
-                    UpdateConfig(reportingResponse).GetAwaiter().GetResult();
+                    UpdateServiceConfig(reportingResponse);
+                    UpdateFirewallLists().GetAwaiter().GetResult();
                 }
             });
 
@@ -461,7 +462,8 @@ namespace Aikido.Zen.Core
                     {
                         if (ConfigChanged(out var response))
                         {
-                            await UpdateConfig(response);
+                            UpdateServiceConfig(response);
+                            await UpdateFirewallLists();
                         }
                         _lastConfigCheck = DateTime.UtcNow.Ticks;
                     }
@@ -614,7 +616,7 @@ namespace Aikido.Zen.Core
                 return false;
             }
 
-            if (latestConfigVersion.ConfigUpdatedAt == _context.Config.ConfigLastUpdated)
+            if (latestConfigVersion.ConfigUpdatedAt <= _context.Config.ConfigLastUpdated)
             {
                 // Check worked but config is the same
                 latestConfig = new ReportingAPIResponse { Success = true, ConfigUpdatedAt = latestConfigVersion.ConfigUpdatedAt };
@@ -628,10 +630,9 @@ namespace Aikido.Zen.Core
             return latestConfig.Success;
         }
 
-        private async Task UpdateConfig(ReportingAPIResponse response)
+        private void UpdateServiceConfig(ReportingAPIResponse response)
         {
-            _context.UpdateConfig(response);
-            await UpdateFirewallLists();
+            _context.Config.UpdateConfig(response);
         }
 
         internal async Task UpdateFirewallLists()
@@ -641,7 +642,7 @@ namespace Aikido.Zen.Core
             var firewallListsResponse = await _api.Reporting.GetFirewallLists(EnvironmentHelper.Token, _cancellationSource.Token);
             if (firewallListsResponse.Success)
             {
-                _context.UpdateFirewallLists(firewallListsResponse);
+                _context.Config.UpdateFirewallLists(firewallListsResponse);
             }
         }
 

--- a/Aikido.Zen.Core/Agent.cs
+++ b/Aikido.Zen.Core/Agent.cs
@@ -26,7 +26,7 @@ namespace Aikido.Zen.Core
         private readonly CancellationTokenSource _cancellationSource;
         private readonly Task _backgroundTask;
         private readonly ConcurrentDictionary<string, ScheduledItem> _scheduledEvents;
-        private long _lastConfigCheck = DateTime.UtcNow.Ticks;
+        internal DateTime LastConfigCheck { get; set; } = DateTime.UtcNow;
         public static ILogger Logger = new DefaultLogger();
 
         private readonly ReportingStatus _reportingStatus = new ReportingStatus();
@@ -457,16 +457,7 @@ namespace Aikido.Zen.Core
             {
                 try
                 {
-                    // check for config updates every minute
-                    if (_lastConfigCheck + TimeSpan.FromMinutes(1).Ticks < DateTime.UtcNow.Ticks)
-                    {
-                        if (ConfigChanged(out var response))
-                        {
-                            UpdateServiceConfig(response);
-                            await UpdateFirewallLists();
-                        }
-                        _lastConfigCheck = DateTime.UtcNow.Ticks;
-                    }
+                    await CheckConfigUpdates();
 
                     await ProcessScheduledEvents();
                     // we rate limit ourselves to 10 requests per second to the Zen API
@@ -628,6 +619,21 @@ namespace Aikido.Zen.Core
 
             // Trigger config change if new configuration retrieved successfully
             return latestConfig.Success;
+        }
+
+        internal async Task CheckConfigUpdates()
+        {
+            // check for config updates every minute
+            if (LastConfigCheck + TimeSpan.FromMinutes(1) >= DateTime.UtcNow)
+                return;
+
+            if (ConfigChanged(out var response))
+            {
+                UpdateServiceConfig(response);
+                await UpdateFirewallLists();
+            }
+
+            LastConfigCheck = DateTime.UtcNow;
         }
 
         private void UpdateServiceConfig(ReportingAPIResponse response)

--- a/Aikido.Zen.Core/Api/Models/ReportingAPIResponse.cs
+++ b/Aikido.Zen.Core/Api/Models/ReportingAPIResponse.cs
@@ -21,23 +21,23 @@ namespace Aikido.Zen.Core.Api
         /// <summary>
         /// Gets or sets the collection of endpoint configurations.
         /// </summary>
-        public IEnumerable<EndpointConfig> Endpoints { get; set; } = new List<EndpointConfig>();
+        public IEnumerable<EndpointConfig> Endpoints { get; set; }
 
         /// <summary>
         /// Gets or sets the collection of blocked user IDs.
         /// </summary>
-        public IEnumerable<string> BlockedUserIds { get; set; } = new List<string>();
+        public IEnumerable<string> BlockedUserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the collection of user IDs that should bypass rate limiting.
         /// </summary>
-        public IEnumerable<string> ExcludedUserIdsFromRateLimiting { get; set; } = new List<string>();
+        public IEnumerable<string> ExcludedUserIdsFromRateLimiting { get; set; }
 
         /// <summary>
         /// Gets or sets the collection of bypassed IP addresses.
         /// </summary>
         [System.Text.Json.Serialization.JsonPropertyName("allowedIPAddresses")]
-        public IEnumerable<string> BypassedIPAddresses { get; set; } = new List<string>(); // we call this bypassed ip addresses, to aovid confusion with allowed ip addresses present on the lists endpoint
+        public IEnumerable<string> BypassedIPAddresses { get; set; } // we call this bypassed ip addresses, to aovid confusion with allowed ip addresses present on the lists endpoint
 
         /// <summary>
         /// Gets or sets a value indicating whether any statistics were received.
@@ -47,7 +47,7 @@ namespace Aikido.Zen.Core.Api
         /// <summary>
         /// Gets or sets a value indicating whether blocking is enabled.
         /// </summary>
-        public bool Block { get; set; }
+        public bool? Block { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether unknown outgoing requests should be blocked.

--- a/Aikido.Zen.Core/Api/Models/ReportingAPIResponse.cs
+++ b/Aikido.Zen.Core/Api/Models/ReportingAPIResponse.cs
@@ -26,7 +26,7 @@ namespace Aikido.Zen.Core.Api
         /// <summary>
         /// Gets or sets the collection of blocked user IDs.
         /// </summary>
-        public IEnumerable<string> BlockedUserIds { get; set; }
+        public IEnumerable<string> BlockedUserIds { get; set; } = new List<string>();
 
         /// <summary>
         /// Gets or sets the collection of user IDs that should bypass rate limiting.
@@ -37,7 +37,7 @@ namespace Aikido.Zen.Core.Api
         /// Gets or sets the collection of bypassed IP addresses.
         /// </summary>
         [System.Text.Json.Serialization.JsonPropertyName("allowedIPAddresses")]
-        public IEnumerable<string> BypassedIPAddresses { get; set; } // we call this bypassed ip addresses, to aovid confusion with allowed ip addresses present on the lists endpoint
+        public IEnumerable<string> BypassedIPAddresses { get; set; } = new List<string>(); // we call this bypassed ip addresses, to aovid confusion with allowed ip addresses present on the lists endpoint
 
         /// <summary>
         /// Gets or sets a value indicating whether any statistics were received.

--- a/Aikido.Zen.Core/Api/Models/ReportingAPIResponse.cs
+++ b/Aikido.Zen.Core/Api/Models/ReportingAPIResponse.cs
@@ -26,7 +26,7 @@ namespace Aikido.Zen.Core.Api
         /// <summary>
         /// Gets or sets the collection of blocked user IDs.
         /// </summary>
-        public IEnumerable<string> BlockedUserIds { get; set; } = new List<string>();
+        public IEnumerable<string> BlockedUserIds { get; set; }
 
         /// <summary>
         /// Gets or sets the collection of user IDs that should bypass rate limiting.
@@ -37,7 +37,7 @@ namespace Aikido.Zen.Core.Api
         /// Gets or sets the collection of bypassed IP addresses.
         /// </summary>
         [System.Text.Json.Serialization.JsonPropertyName("allowedIPAddresses")]
-        public IEnumerable<string> BypassedIPAddresses { get; set; } = new List<string>(); // we call this bypassed ip addresses, to aovid confusion with allowed ip addresses present on the lists endpoint
+        public IEnumerable<string> BypassedIPAddresses { get; set; } // we call this bypassed ip addresses, to aovid confusion with allowed ip addresses present on the lists endpoint
 
         /// <summary>
         /// Gets or sets a value indicating whether any statistics were received.

--- a/Aikido.Zen.Core/Models/AgentConfiguration.cs
+++ b/Aikido.Zen.Core/Models/AgentConfiguration.cs
@@ -222,6 +222,8 @@ namespace Aikido.Zen.Core.Models
         public void UpdateConfig(ReportingAPIResponse response)
         {
             if (response == null) return;
+            ConfigLastUpdated = response.ConfigUpdatedAt;
+
             if (response.Block.HasValue)
             {
                 Environment.SetEnvironmentVariable("AIKIDO_BLOCK", response.Block.Value ? "true" : "false");
@@ -233,7 +235,6 @@ namespace Aikido.Zen.Core.Models
                 BlockList.UpdateAllowedIpsPerEndpoint(response.Endpoints);
                 BlockList.UpdateBypassedIps(response.BypassedIPAddresses ?? Enumerable.Empty<string>());
                 UpdateRatelimitedRoutes(response.Endpoints);
-                ConfigLastUpdated = response.ConfigUpdatedAt;
             }
 
             if (response.ExcludedUserIdsFromRateLimiting != null)

--- a/Aikido.Zen.Core/Models/AgentConfiguration.cs
+++ b/Aikido.Zen.Core/Models/AgentConfiguration.cs
@@ -222,16 +222,30 @@ namespace Aikido.Zen.Core.Models
         public void UpdateConfig(ReportingAPIResponse response)
         {
             if (response == null) return;
-            Environment.SetEnvironmentVariable("AIKIDO_BLOCK", response.Block ? "true" : "false");
-            UpdateBlockedUsers(response.BlockedUserIds);
-            UpdateUsersExcludedFromRateLimiting(response.ExcludedUserIdsFromRateLimiting);
-            BlockList.UpdateAllowedIpsPerEndpoint(response.Endpoints);
-            BlockList.UpdateBypassedIps(response.BypassedIPAddresses);
-            UpdateRatelimitedRoutes(response.Endpoints);
-            ConfigLastUpdated = response.ConfigUpdatedAt;
+            if (response.Block.HasValue)
+            {
+                Environment.SetEnvironmentVariable("AIKIDO_BLOCK", response.Block.Value ? "true" : "false");
+            }
 
-            HeartbeatIntervalInMS = response.HeartbeatIntervalInMS;
-            Heartbeat.UpdateDefaultInterval(response.HeartbeatIntervalInMS);
+            if (response.Endpoints != null)
+            {
+                UpdateBlockedUsers(response.BlockedUserIds ?? Enumerable.Empty<string>());
+                BlockList.UpdateAllowedIpsPerEndpoint(response.Endpoints);
+                BlockList.UpdateBypassedIps(response.BypassedIPAddresses ?? Enumerable.Empty<string>());
+                UpdateRatelimitedRoutes(response.Endpoints);
+                ConfigLastUpdated = response.ConfigUpdatedAt;
+            }
+
+            if (response.ExcludedUserIdsFromRateLimiting != null)
+            {
+                UpdateUsersExcludedFromRateLimiting(response.ExcludedUserIdsFromRateLimiting);
+            }
+
+            if (response.HeartbeatIntervalInMS > 0)
+            {
+                HeartbeatIntervalInMS = response.HeartbeatIntervalInMS;
+                Heartbeat.UpdateDefaultInterval(response.HeartbeatIntervalInMS);
+            }
 
             if (response.BlockNewOutgoingRequests.HasValue && response.Domains != null)
             {

--- a/Aikido.Zen.Core/Models/AgentConfiguration.cs
+++ b/Aikido.Zen.Core/Models/AgentConfiguration.cs
@@ -231,9 +231,9 @@ namespace Aikido.Zen.Core.Models
 
             if (response.Endpoints != null)
             {
-                UpdateBlockedUsers(response.BlockedUserIds ?? Enumerable.Empty<string>());
+                UpdateBlockedUsers(response.BlockedUserIds);
                 BlockList.UpdateAllowedIpsPerEndpoint(response.Endpoints);
-                BlockList.UpdateBypassedIps(response.BypassedIPAddresses ?? Enumerable.Empty<string>());
+                BlockList.UpdateBypassedIps(response.BypassedIPAddresses);
                 UpdateRatelimitedRoutes(response.Endpoints);
             }
 

--- a/Aikido.Zen.Core/Models/AgentConfiguration.cs
+++ b/Aikido.Zen.Core/Models/AgentConfiguration.cs
@@ -231,9 +231,9 @@ namespace Aikido.Zen.Core.Models
 
             if (response.Endpoints != null)
             {
-                UpdateBlockedUsers(response.BlockedUserIds);
+                UpdateBlockedUsers(response.BlockedUserIds ?? Enumerable.Empty<string>());
                 BlockList.UpdateAllowedIpsPerEndpoint(response.Endpoints);
-                BlockList.UpdateBypassedIps(response.BypassedIPAddresses);
+                BlockList.UpdateBypassedIps(response.BypassedIPAddresses ?? Enumerable.Empty<string>());
                 UpdateRatelimitedRoutes(response.Endpoints);
             }
 

--- a/Aikido.Zen.Core/Models/AgentContext.cs
+++ b/Aikido.Zen.Core/Models/AgentContext.cs
@@ -1,10 +1,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using Aikido.Zen.Core.Api;
 using Aikido.Zen.Core.Helpers;
 using Aikido.Zen.Core.Helpers.OpenAPI;
-using Aikido.Zen.Core.Models.Ip;
 
 namespace Aikido.Zen.Core.Models
 {
@@ -219,7 +216,7 @@ namespace Aikido.Zen.Core.Models
         {
             reason = null;
             // Check if user exists and is blocked
-            if (context.User != null && IsUserBlocked(context.User.Id))
+            if (context.User != null && _config.IsUserBlocked(context.User.Id))
             {
                 reason = "User is blocked";
                 return true;
@@ -248,7 +245,7 @@ namespace Aikido.Zen.Core.Models
                 return true;
             }
 
-            var isUserAgentBlocked = IsUserAgentBlocked(context.UserAgent);
+            var isUserAgentBlocked = _config.IsUserAgentBlocked(context.UserAgent);
             var isMonitoredUserAgent = _config.IsMonitoredUserAgent(context.UserAgent);
             if (isUserAgentBlocked || isMonitoredUserAgent)
             {
@@ -264,65 +261,11 @@ namespace Aikido.Zen.Core.Models
             return false;
         }
 
-        public bool IsUserBlocked(string userId)
-        {
-            return _config.IsUserBlocked(userId);
-        }
-
-        public bool IsUserExcludedFromRateLimiting(string userId)
-        {
-            return _config.IsUserExcludedFromRateLimiting(userId);
-        }
-
-        public bool IsUserAgentBlocked(string userAgent)
-        {
-            if (string.IsNullOrWhiteSpace(userAgent))
-                return false;
-
-            return Config.IsUserAgentBlocked(userAgent);
-        }
-
-        public void UpdateBlockedUsers(IEnumerable<string> users)
-        {
-            _config.UpdateBlockedUsers(users);
-        }
-
-        public void UpdateUsersExcludedFromRateLimiting(IEnumerable<string> users)
-        {
-            _config.UpdateUsersExcludedFromRateLimiting(users);
-        }
-
-        public void UpdateRatelimitedRoutes(IEnumerable<EndpointConfig> endpoints)
-        {
-            _config.UpdateRatelimitedRoutes(endpoints);
-        }
-
-        public bool IsProtectionDisabledForEndpoint(Context context)
-        {
-            return _config.IsProtectionDisabledForEndpoint(context);
-        }
-
-        public void UpdateConfig(ReportingAPIResponse response)
-        {
-            _config.UpdateConfig(response);
-        }
-
-        public void UpdateFirewallLists(FirewallListsAPIResponse response)
-        {
-            _config.UpdateFirewallLists(response);
-        }
-
-        public void UpdateBlockedUserAgents(string blockedUserAgents)
-        {
-            _config.UpdateBlockedUserAgents(blockedUserAgents);
-        }
-
         public IEnumerable<Host> Hostnames => _hostnames.GetValues();
         public IEnumerable<UserExtended> Users => _users.GetValues();
         public IEnumerable<Route> Routes => _routes.GetValues();
         public IEnumerable<Package> Packages => _packages.Values;
 
-        public IEnumerable<EndpointConfig> Endpoints => _config.Endpoints;
         public int Requests => _stats.Requests.Total;
         public int RequestsAborted => _stats.Requests.Aborted;
         public int RequestsRateLimited => _stats.Requests.RateLimited;
@@ -331,8 +274,6 @@ namespace Aikido.Zen.Core.Models
         public int AttackWavesDetected => _stats.Requests.AttackWaves.Total;
         public int AttackWavesBlocked => _stats.Requests.AttackWaves.Blocked;
         public long Started => _stats.StartedAt;
-        internal BlockList BlockList => _config.BlockList;
-        public Regex BlockedUserAgents => _config.BlockedUserAgents;
         public AgentStats Stats => _stats;
         public AiStats AiStats => _aiStats;
         public AgentConfiguration Config => _config;

--- a/Aikido.Zen.Core/Sinks/Inspector.cs
+++ b/Aikido.Zen.Core/Sinks/Inspector.cs
@@ -31,7 +31,7 @@ namespace Aikido.Zen.Core.Sinks
                 try
                 {
                     if (Context.IsBypassed(context) ||
-                        Agent.Instance.Context.IsProtectionDisabledForEndpoint(context))
+                        Agent.Instance.Context.Config.IsProtectionDisabledForEndpoint(context))
                     {
                         return true;
                     }

--- a/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
@@ -50,7 +50,7 @@ namespace Aikido.Zen.DotNetCore.Middleware
                 var remoteAddress = HttpUtility.HtmlEncode(aikidoContext.RemoteAddress); // HTML escape the remote address
 
                 // Use the helper to check all rate limiting rules
-                var (isAllowed, effectiveConfig) = RateLimitingHelper.IsRequestAllowed(aikidoContext, agentContext.Endpoints, agentContext.Config);
+                var (isAllowed, effectiveConfig) = RateLimitingHelper.IsRequestAllowed(aikidoContext, agentContext.Config.Endpoints, agentContext.Config);
 
                 if (!isAllowed)
                 {

--- a/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
@@ -40,7 +40,7 @@ namespace Aikido.Zen.DotNetCore.Middleware
                 return;
             }
 
-            if (Agent.Instance.Context.BlockList.IsIPBypassed(context.RemoteAddress))
+            if (Agent.Instance.Context.Config.BlockList.IsIPBypassed(context.RemoteAddress))
             {
                 // Store bypass marker context so patches can still honor bypass.
                 httpContext.Items["Aikido.Zen.Context"] = new Context { Bypassed = true };

--- a/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
@@ -65,7 +65,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                 }
 
                 // Use the helper to check all rate limiting rules
-                var (isAllowed, effectiveConfig) = RateLimitingHelper.IsRequestAllowed(aikidoContext, agentContext.Endpoints, agentContext.Config);
+                var (isAllowed, effectiveConfig) = RateLimitingHelper.IsRequestAllowed(aikidoContext, agentContext.Config.Endpoints, agentContext.Config);
 
                 if (!isAllowed)
                 {

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -98,7 +98,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                 }
 
                 // Store bypass marker context so patches can still honor bypass
-                if (Agent.Instance.Context.BlockList.IsIPBypassed(clientIp))
+                if (Agent.Instance.Context.Config.BlockList.IsIPBypassed(clientIp))
                 {
                     httpContext.Items["Aikido.Zen.Context"] = new Context { Bypassed = true };
                     return;

--- a/Aikido.Zen.Test/AgentConfigurationTests.cs
+++ b/Aikido.Zen.Test/AgentConfigurationTests.cs
@@ -122,27 +122,17 @@ namespace Aikido.Zen.Test
         public void UpdateConfig_WithOmittedFields_PreservesExistingValues()
         {
             // Arrange
-            var originalBlock = Environment.GetEnvironmentVariable("AIKIDO_BLOCK");
-            Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "true");
             _config.UpdateBlockedUsers(new[] { "existing-user" });
 
-            try
-            {
-                // Act
-                _config.UpdateConfig(new ReportingAPIResponse { Success = true });
+            // Act
+            _config.UpdateConfig(new ReportingAPIResponse { Success = true });
 
-                // Assert
-                Assert.Multiple(() =>
-                {
-                    Assert.That(Environment.GetEnvironmentVariable("AIKIDO_BLOCK"), Is.EqualTo("true"));
-                    Assert.That(_config.IsUserBlocked("existing-user"), Is.True);
-                    Assert.That(_config.ConfigLastUpdated, Is.Zero);
-                });
-            }
-            finally
+            // Assert
+            Assert.Multiple(() =>
             {
-                Environment.SetEnvironmentVariable("AIKIDO_BLOCK", originalBlock);
-            }
+                Assert.That(_config.IsUserBlocked("existing-user"), Is.True);
+                Assert.That(_config.ConfigLastUpdated, Is.Zero);
+            });
         }
 
         [Test]

--- a/Aikido.Zen.Test/AgentConfigurationTests.cs
+++ b/Aikido.Zen.Test/AgentConfigurationTests.cs
@@ -119,6 +119,33 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
+        public void UpdateConfig_WithOmittedFields_PreservesExistingValues()
+        {
+            // Arrange
+            var originalBlock = Environment.GetEnvironmentVariable("AIKIDO_BLOCK");
+            Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "true");
+            _config.UpdateBlockedUsers(new[] { "existing-user" });
+
+            try
+            {
+                // Act
+                _config.UpdateConfig(new ReportingAPIResponse { Success = true });
+
+                // Assert
+                Assert.Multiple(() =>
+                {
+                    Assert.That(Environment.GetEnvironmentVariable("AIKIDO_BLOCK"), Is.EqualTo("true"));
+                    Assert.That(_config.IsUserBlocked("existing-user"), Is.True);
+                    Assert.That(_config.ConfigLastUpdated, Is.Zero);
+                });
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AIKIDO_BLOCK", originalBlock);
+            }
+        }
+
+        [Test]
         public void ShouldBlockOutgoingRequest_WithExplicitRules_MatchesNodeSemantics()
         {
             // Arrange

--- a/Aikido.Zen.Test/AgentConfigurationTests.cs
+++ b/Aikido.Zen.Test/AgentConfigurationTests.cs
@@ -149,8 +149,6 @@ namespace Aikido.Zen.Test
         public void UpdateConfig_WithOmittedEndpoints_UpdatesConfigLastUpdated()
         {
             // Arrange
-            var originalBlock = Environment.GetEnvironmentVariable("AIKIDO_BLOCK");
-            Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "true");
             _config.UpdateConfig(new ReportingAPIResponse
             {
                 BlockedUserIds = new[] { "existing-user" },
@@ -165,29 +163,20 @@ namespace Aikido.Zen.Test
                 ConfigUpdatedAt = 100
             });
 
-            try
+            // Act
+            _config.UpdateConfig(new ReportingAPIResponse
             {
-                // Act
-                _config.UpdateConfig(new ReportingAPIResponse
-                {
-                    Success = true,
-                    Block = false,
-                    ConfigUpdatedAt = 200
-                });
+                Success = true,
+                ConfigUpdatedAt = 200
+            });
 
-                // Assert
-                Assert.Multiple(() =>
-                {
-                    Assert.That(_config.ConfigLastUpdated, Is.EqualTo(200));
-                    Assert.That(Environment.GetEnvironmentVariable("AIKIDO_BLOCK"), Is.EqualTo("false"));
-                    Assert.That(_config.IsUserBlocked("existing-user"), Is.True);
-                    Assert.That(_config.Endpoints.Single().Route, Is.EqualTo("/existing"));
-                });
-            }
-            finally
+            // Assert
+            Assert.Multiple(() =>
             {
-                Environment.SetEnvironmentVariable("AIKIDO_BLOCK", originalBlock);
-            }
+                Assert.That(_config.ConfigLastUpdated, Is.EqualTo(200));
+                Assert.That(_config.IsUserBlocked("existing-user"), Is.True);
+                Assert.That(_config.Endpoints.Single().Route, Is.EqualTo("/existing"));
+            });
         }
 
         [Test]

--- a/Aikido.Zen.Test/AgentConfigurationTests.cs
+++ b/Aikido.Zen.Test/AgentConfigurationTests.cs
@@ -2,6 +2,7 @@
 using Aikido.Zen.Core;
 using Aikido.Zen.Core.Api;
 using Aikido.Zen.Core.Models;
+using Aikido.Zen.Core.Models.Events;
 
 namespace Aikido.Zen.Test
 {
@@ -166,6 +167,56 @@ namespace Aikido.Zen.Test
                 Assert.That(_config.ConfigLastUpdated, Is.EqualTo(200));
                 Assert.That(_config.IsUserBlocked("existing-user"), Is.True);
                 Assert.That(_config.Endpoints.Single().Route, Is.EqualTo("/existing"));
+            });
+        }
+
+        [Test]
+        public void UpdateConfig_WithOmittedEndpointLists_UsesEmptyLists()
+        {
+            // Arrange
+            _config.UpdateBlockedUsers(new[] { "existing-user" });
+            _config.BlockList.UpdateBypassedIps(new[] { "203.0.113.10" });
+
+            // Act
+            _config.UpdateConfig(new ReportingAPIResponse
+            {
+                Endpoints = new[]
+                {
+                    new EndpointConfig
+                    {
+                        Method = "GET",
+                        Route = "/without-lists"
+                    }
+                },
+                ConfigUpdatedAt = 300
+            });
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(_config.IsUserBlocked("existing-user"), Is.False);
+                Assert.That(_config.BlockList.IsIPBypassed("203.0.113.10"), Is.False);
+                Assert.That(_config.Endpoints.Single().Route, Is.EqualTo("/without-lists"));
+            });
+        }
+
+        [Test]
+        public void UpdateConfig_WithHeartbeatInterval_UpdatesHeartbeatInterval()
+        {
+            // Arrange
+            const int heartbeatIntervalInMs = 10 * 60 * 1000;
+
+            // Act
+            _config.UpdateConfig(new ReportingAPIResponse
+            {
+                HeartbeatIntervalInMS = heartbeatIntervalInMs
+            });
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(_config.HeartbeatIntervalInMS, Is.EqualTo(heartbeatIntervalInMs));
+                Assert.That(Heartbeat.DefaultInterval, Is.EqualTo(TimeSpan.FromMilliseconds(heartbeatIntervalInMs)));
             });
         }
 

--- a/Aikido.Zen.Test/AgentConfigurationTests.cs
+++ b/Aikido.Zen.Test/AgentConfigurationTests.cs
@@ -146,6 +146,51 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
+        public void UpdateConfig_WithOmittedEndpoints_UpdatesConfigLastUpdated()
+        {
+            // Arrange
+            var originalBlock = Environment.GetEnvironmentVariable("AIKIDO_BLOCK");
+            Environment.SetEnvironmentVariable("AIKIDO_BLOCK", "true");
+            _config.UpdateConfig(new ReportingAPIResponse
+            {
+                BlockedUserIds = new[] { "existing-user" },
+                Endpoints = new[]
+                {
+                    new EndpointConfig
+                    {
+                        Method = "GET",
+                        Route = "/existing"
+                    }
+                },
+                ConfigUpdatedAt = 100
+            });
+
+            try
+            {
+                // Act
+                _config.UpdateConfig(new ReportingAPIResponse
+                {
+                    Success = true,
+                    Block = false,
+                    ConfigUpdatedAt = 200
+                });
+
+                // Assert
+                Assert.Multiple(() =>
+                {
+                    Assert.That(_config.ConfigLastUpdated, Is.EqualTo(200));
+                    Assert.That(Environment.GetEnvironmentVariable("AIKIDO_BLOCK"), Is.EqualTo("false"));
+                    Assert.That(_config.IsUserBlocked("existing-user"), Is.True);
+                    Assert.That(_config.Endpoints.Single().Route, Is.EqualTo("/existing"));
+                });
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AIKIDO_BLOCK", originalBlock);
+            }
+        }
+
+        [Test]
         public void ShouldBlockOutgoingRequest_WithExplicitRules_MatchesNodeSemantics()
         {
             // Arrange

--- a/Aikido.Zen.Test/AgentContextTests.cs
+++ b/Aikido.Zen.Test/AgentContextTests.cs
@@ -20,26 +20,26 @@ namespace Aikido.Zen.Test
             var users = new[] { "user1", "user2", "user3" };
 
             // Act
-            _agentContext.UpdateBlockedUsers(users);
+            _agentContext.Config.UpdateBlockedUsers(users);
 
             // Assert
-            Assert.That(_agentContext.IsUserBlocked("user1"), Is.True);
-            Assert.That(_agentContext.IsUserBlocked("user2"), Is.True);
-            Assert.That(_agentContext.IsUserBlocked("user3"), Is.True);
-            Assert.That(_agentContext.IsUserBlocked("user4"), Is.False);
+            Assert.That(_agentContext.Config.IsUserBlocked("user1"), Is.True);
+            Assert.That(_agentContext.Config.IsUserBlocked("user2"), Is.True);
+            Assert.That(_agentContext.Config.IsUserBlocked("user3"), Is.True);
+            Assert.That(_agentContext.Config.IsUserBlocked("user4"), Is.False);
         }
 
         [Test]
         public void UpdateBlockedUsers_WithEmptyList_ShouldClearBlockedUsers()
         {
             // Arrange
-            _agentContext.UpdateBlockedUsers(new[] { "user1" });
+            _agentContext.Config.UpdateBlockedUsers(new[] { "user1" });
 
             // Act
-            _agentContext.UpdateBlockedUsers(System.Array.Empty<string>());
+            _agentContext.Config.UpdateBlockedUsers(System.Array.Empty<string>());
 
             // Assert
-            Assert.That(_agentContext.IsUserBlocked("user1"), Is.False);
+            Assert.That(_agentContext.Config.IsUserBlocked("user1"), Is.False);
         }
 
         [Test]
@@ -49,26 +49,26 @@ namespace Aikido.Zen.Test
             var users = new[] { "user1", "user2", "user3" };
 
             // Act
-            _agentContext.UpdateUsersExcludedFromRateLimiting(users);
+            _agentContext.Config.UpdateUsersExcludedFromRateLimiting(users);
 
             // Assert
-            Assert.That(_agentContext.IsUserExcludedFromRateLimiting("user1"), Is.True);
-            Assert.That(_agentContext.IsUserExcludedFromRateLimiting("user2"), Is.True);
-            Assert.That(_agentContext.IsUserExcludedFromRateLimiting("user3"), Is.True);
-            Assert.That(_agentContext.IsUserExcludedFromRateLimiting("user4"), Is.False);
+            Assert.That(_agentContext.Config.IsUserExcludedFromRateLimiting("user1"), Is.True);
+            Assert.That(_agentContext.Config.IsUserExcludedFromRateLimiting("user2"), Is.True);
+            Assert.That(_agentContext.Config.IsUserExcludedFromRateLimiting("user3"), Is.True);
+            Assert.That(_agentContext.Config.IsUserExcludedFromRateLimiting("user4"), Is.False);
         }
 
         [Test]
         public void UpdateUsersExcludedFromRateLimiting_WithEmptyList_ShouldClearExcludedUsers()
         {
             // Arrange
-            _agentContext.UpdateUsersExcludedFromRateLimiting(new[] { "user1" });
+            _agentContext.Config.UpdateUsersExcludedFromRateLimiting(new[] { "user1" });
 
             // Act
-            _agentContext.UpdateUsersExcludedFromRateLimiting(System.Array.Empty<string>());
+            _agentContext.Config.UpdateUsersExcludedFromRateLimiting(System.Array.Empty<string>());
 
             // Assert
-            Assert.That(_agentContext.IsUserExcludedFromRateLimiting("user1"), Is.False);
+            Assert.That(_agentContext.Config.IsUserExcludedFromRateLimiting("user1"), Is.False);
         }
 
         [Test]
@@ -87,10 +87,10 @@ namespace Aikido.Zen.Test
             };
             var blockedUserAgents = "googlebot|bingbot|yandexbot";
 
-            _agentContext.UpdateBlockedUsers(new[] { "user1" });
-            _agentContext.BlockList.UpdateBlockedIps(new[] { ("manual", (IEnumerable<string>)new[] { "8.8.8.101" }) });  // Using public IP
-            _agentContext.BlockList.UpdateAllowedIpsPerEndpoint(endpoints);
-            _agentContext.UpdateBlockedUserAgents(blockedUserAgents);
+            _agentContext.Config.UpdateBlockedUsers(new[] { "user1" });
+            _agentContext.Config.BlockList.UpdateBlockedIps(new[] { ("manual", (IEnumerable<string>)new[] { "8.8.8.101" }) });  // Using public IP
+            _agentContext.Config.BlockList.UpdateAllowedIpsPerEndpoint(endpoints);
+            _agentContext.Config.UpdateBlockedUserAgents(blockedUserAgents);
 
             // Act & Assert
             var context1 = new Context { User = user, RemoteAddress = "8.8.8.102", Method = "GET", Url = url, UserAgent = "useragent", Route = "testUrl" };
@@ -124,7 +124,7 @@ namespace Aikido.Zen.Test
                 Key = "googlebot",
                 Pattern = "googlebot"
             };
-            _agentContext.UpdateFirewallLists(new FirewallListsAPIResponse
+            _agentContext.Config.UpdateFirewallLists(new FirewallListsAPIResponse
             {
                 MonitoredIPAddresses = new[] { monitoredIpList },
                 MonitoredUserAgents = "googlebot",
@@ -162,12 +162,12 @@ namespace Aikido.Zen.Test
                 Key = "tor/exit_nodes",
                 Ips = new[] { "8.8.8.0/24" }
             };
-            _agentContext.UpdateFirewallLists(new FirewallListsAPIResponse
+            _agentContext.Config.UpdateFirewallLists(new FirewallListsAPIResponse
             {
                 MonitoredIPAddresses = new[] { monitoredIpList }
             });
 
-            _agentContext.BlockList.UpdateAllowedIpsPerEndpoint(new[]
+            _agentContext.Config.BlockList.UpdateAllowedIpsPerEndpoint(new[]
             {
                 new EndpointConfig
                 {
@@ -211,7 +211,7 @@ namespace Aikido.Zen.Test
                 Key = "known_threat_actors/public_scanners",
                 Ips = new[] { "8.8.8.0/24" }
             };
-            _agentContext.UpdateFirewallLists(new FirewallListsAPIResponse
+            _agentContext.Config.UpdateFirewallLists(new FirewallListsAPIResponse
             {
                 MonitoredIPAddresses = new[] { monitoredIpList },
                 BlockedIPAddresses = new[] { blockedIpList }
@@ -474,7 +474,7 @@ namespace Aikido.Zen.Test
         public void IsBlocked_ShouldReturnTrue_WhenUserIsBlocked()
         {
             // Arrange
-            _agentContext.UpdateBlockedUsers(new[] { "user1" });
+            _agentContext.Config.UpdateBlockedUsers(new[] { "user1" });
             var context = new Context { User = new User("user1", "Blocked User"), RemoteAddress = string.Empty, Method = string.Empty, Url = string.Empty, UserAgent = string.Empty };
 
             // Act
@@ -489,7 +489,7 @@ namespace Aikido.Zen.Test
         public void IsBlocked_ShouldReturnFalse_WhenUserIsNotBlocked()
         {
             // Arrange
-            _agentContext.UpdateBlockedUsers(new[] { "user1" });
+            _agentContext.Config.UpdateBlockedUsers(new[] { "user1" });
             var context = new Context { User = new User("user2", "Not Blocked User"), RemoteAddress = string.Empty, Method = string.Empty, Url = string.Empty, UserAgent = string.Empty };
 
             // Act
@@ -518,10 +518,10 @@ namespace Aikido.Zen.Test
             };
 
             // Act
-            _agentContext.UpdateRatelimitedRoutes(endpoints);
+            _agentContext.Config.UpdateRatelimitedRoutes(endpoints);
 
             // Assert
-            var endpointsList = _agentContext.Endpoints.ToList();
+            var endpointsList = _agentContext.Config.Endpoints.ToList();
             Assert.That(endpointsList.Count, Is.EqualTo(2));
 
             var endpoint1 = endpointsList.FirstOrDefault(e => e.Method == "GET" && e.Route == "/api/test1");
@@ -546,7 +546,7 @@ namespace Aikido.Zen.Test
                     RateLimiting = new RateLimitingConfig { MaxRequests = 100 }
                 }
             };
-            _agentContext.UpdateRatelimitedRoutes(initialEndpoints);
+            _agentContext.Config.UpdateRatelimitedRoutes(initialEndpoints);
 
             var newEndpoints = new List<EndpointConfig> {
                 new EndpointConfig {
@@ -557,10 +557,10 @@ namespace Aikido.Zen.Test
             };
 
             // Act
-            _agentContext.UpdateRatelimitedRoutes(newEndpoints);
+            _agentContext.Config.UpdateRatelimitedRoutes(newEndpoints);
 
             // Assert
-            var endpointsList = _agentContext.Endpoints.ToList();
+            var endpointsList = _agentContext.Config.Endpoints.ToList();
             Assert.That(endpointsList.Count, Is.EqualTo(1));
             Assert.That(endpointsList.Any(e => e.Method == "GET" && e.Route == "/api/new"), Is.True);
             Assert.That(endpointsList.Any(e => e.Method == "GET" && e.Route == "/api/old"), Is.False);
@@ -569,7 +569,7 @@ namespace Aikido.Zen.Test
         [Test]
         public void IsProtectionDisabledForEndpoint_ShouldReturnTrue_WhenMatchingEndpointDisablesProtection()
         {
-            _agentContext.UpdateRatelimitedRoutes(new[]
+            _agentContext.Config.UpdateRatelimitedRoutes(new[]
             {
                 new EndpointConfig
                 {
@@ -587,7 +587,7 @@ namespace Aikido.Zen.Test
                 Url = "https://app.local/api/stored_ssrf"
             };
 
-            Assert.That(_agentContext.IsProtectionDisabledForEndpoint(context), Is.True);
+            Assert.That(_agentContext.Config.IsProtectionDisabledForEndpoint(context), Is.True);
         }
 
         [Test]
@@ -618,16 +618,16 @@ namespace Aikido.Zen.Test
             };
 
             // Act
-            _agentContext.UpdateConfig(response);
+            _agentContext.Config.UpdateConfig(response);
 
             // Assert
             Assert.Multiple(() =>
             {
                 Assert.That(Environment.GetEnvironmentVariable("AIKIDO_BLOCK"), Is.EqualTo("true"));
-                Assert.That(_agentContext.IsUserBlocked("user1"), Is.True);
-                Assert.That(_agentContext.IsUserBlocked("user2"), Is.True);
+                Assert.That(_agentContext.Config.IsUserBlocked("user1"), Is.True);
+                Assert.That(_agentContext.Config.IsUserBlocked("user2"), Is.True);
 
-                var endpointsList = _agentContext.Endpoints.ToList();
+                var endpointsList = _agentContext.Config.Endpoints.ToList();
                 var endpoint = endpointsList.FirstOrDefault(e => e.Method == "GET" && e.Route == "/test");
                 Assert.That(endpoint, Is.Not.Null);
                 Assert.That(endpoint.RateLimiting.MaxRequests, Is.EqualTo(60));
@@ -649,14 +649,14 @@ namespace Aikido.Zen.Test
             var firewallAPiResponse = new FirewallListsAPIResponse { BlockedIPAddresses = new[] { blockedIPList } };
 
             // Act
-            _agentContext.UpdateFirewallLists(firewallAPiResponse);
+            _agentContext.Config.UpdateFirewallLists(firewallAPiResponse);
 
             // Assert
             Assert.Multiple(() =>
             {
-                Assert.That(_agentContext.BlockList.IsIPBlocked("192.168.1.100"), Is.True);
-                Assert.That(_agentContext.BlockList.IsIPBlocked("10.0.0.1"), Is.True);
-                Assert.That(_agentContext.BlockList.IsIPBlocked("172.16.0.1"), Is.False);
+                Assert.That(_agentContext.Config.BlockList.IsIPBlocked("192.168.1.100"), Is.True);
+                Assert.That(_agentContext.Config.BlockList.IsIPBlocked("10.0.0.1"), Is.True);
+                Assert.That(_agentContext.Config.BlockList.IsIPBlocked("172.16.0.1"), Is.False);
             });
         }
 
@@ -672,13 +672,13 @@ namespace Aikido.Zen.Test
             };
 
             var firewallListsAPIResponse = new FirewallListsAPIResponse { BlockedIPAddresses = new[] { ipList } };
-            _agentContext.UpdateFirewallLists(firewallListsAPIResponse);
+            _agentContext.Config.UpdateFirewallLists(firewallListsAPIResponse);
 
             // Act
-            _agentContext.UpdateFirewallLists((FirewallListsAPIResponse?)null);
+            _agentContext.Config.UpdateFirewallLists((FirewallListsAPIResponse?)null);
 
             // Assert
-            Assert.That(_agentContext.BlockList.IsIPBlocked("192.168.1.1"), Is.False);
+            Assert.That(_agentContext.Config.BlockList.IsIPBlocked("192.168.1.1"), Is.False);
         }
 
         [Test]
@@ -694,14 +694,14 @@ namespace Aikido.Zen.Test
             var firewallAPiResponse = new FirewallListsAPIResponse { BlockedIPAddresses = new[] { blockedIpList } };
 
             // Act
-            _agentContext.UpdateFirewallLists(firewallAPiResponse);
+            _agentContext.Config.UpdateFirewallLists(firewallAPiResponse);
 
             // Assert
             Assert.Multiple(() =>
             {
-                Assert.That(_agentContext.BlockList.IsIPBlocked("192.168.1.1"), Is.True);
-                Assert.That(_agentContext.BlockList.IsIPBlocked("invalid-ip"), Is.False);
-                Assert.That(_agentContext.BlockList.IsIPBlocked("not-an-ip"), Is.False);
+                Assert.That(_agentContext.Config.BlockList.IsIPBlocked("192.168.1.1"), Is.True);
+                Assert.That(_agentContext.Config.BlockList.IsIPBlocked("invalid-ip"), Is.False);
+                Assert.That(_agentContext.Config.BlockList.IsIPBlocked("not-an-ip"), Is.False);
             });
         }
 
@@ -712,26 +712,26 @@ namespace Aikido.Zen.Test
             var userAgents = "googlebot|bingbot|yandexbot";
 
             // Act
-            _agentContext.UpdateBlockedUserAgents(userAgents);
+            _agentContext.Config.UpdateBlockedUserAgents(userAgents);
 
             // Assert
-            Assert.That(_agentContext.IsUserAgentBlocked("googlebot"), Is.True);
-            Assert.That(_agentContext.IsUserAgentBlocked("bingbot"), Is.True);
-            Assert.That(_agentContext.IsUserAgentBlocked("yandexbot"), Is.True);
-            Assert.That(_agentContext.IsUserAgentBlocked("Opera/9.80"), Is.False);
+            Assert.That(_agentContext.Config.IsUserAgentBlocked("googlebot"), Is.True);
+            Assert.That(_agentContext.Config.IsUserAgentBlocked("bingbot"), Is.True);
+            Assert.That(_agentContext.Config.IsUserAgentBlocked("yandexbot"), Is.True);
+            Assert.That(_agentContext.Config.IsUserAgentBlocked("Opera/9.80"), Is.False);
         }
 
         [Test]
         public void UpdateBlockedUserAgents_WithEmptyList_ShouldClearBlockedUserAgents()
         {
             // Arrange
-            _agentContext.UpdateBlockedUserAgents("Mozilla/5.0");
+            _agentContext.Config.UpdateBlockedUserAgents("Mozilla/5.0");
 
             // Act
-            _agentContext.UpdateBlockedUserAgents(null);
+            _agentContext.Config.UpdateBlockedUserAgents(null);
 
             // Assert
-            Assert.That(_agentContext.IsUserAgentBlocked("Mozilla/5.0"), Is.False);
+            Assert.That(_agentContext.Config.IsUserAgentBlocked("Mozilla/5.0"), Is.False);
         }
 
         [Test]
@@ -739,10 +739,10 @@ namespace Aikido.Zen.Test
         {
             // Arrange
             var userAgent = "Mozilla/5.0";
-            _agentContext.UpdateBlockedUserAgents(userAgent);
+            _agentContext.Config.UpdateBlockedUserAgents(userAgent);
 
             // Act
-            var isBlocked = _agentContext.IsUserAgentBlocked(userAgent);
+            var isBlocked = _agentContext.Config.IsUserAgentBlocked(userAgent);
 
             // Assert
             Assert.That(isBlocked, Is.True);
@@ -755,7 +755,7 @@ namespace Aikido.Zen.Test
             var userAgent = "Mozilla/5.0";
 
             // Act
-            var isBlocked = _agentContext.IsUserAgentBlocked(userAgent);
+            var isBlocked = _agentContext.Config.IsUserAgentBlocked(userAgent);
 
             // Assert
             Assert.That(isBlocked, Is.False);

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -983,6 +983,72 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
+        public async Task RecurringTasks_WhenRemoteConfigIsNewer_UpdatesConfigAndFirewallLists()
+        {
+            // Arrange
+            var runtimeApiClientMock = new Mock<IRuntimeAPIClient>();
+            runtimeApiClientMock
+                .Setup(x => x.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ConfigLastUpdatedAPIResponse
+                {
+                    Success = true,
+                    ConfigUpdatedAt = 200
+                });
+            runtimeApiClientMock
+                .Setup(x => x.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ReportingAPIResponse
+                {
+                    Success = true,
+                    Endpoints = Array.Empty<EndpointConfig>(),
+                    ConfigUpdatedAt = 200
+                });
+
+            var reportingApiClientMock = new Mock<IReportingAPIClient>();
+            reportingApiClientMock
+                .Setup(x => x.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new FirewallListsAPIResponse
+                {
+                    Success = true,
+                    BlockedIPAddresses = new[]
+                    {
+                        new FirewallListsAPIResponse.IPList
+                        {
+                            Key = "recurring-test-list",
+                            Ips = new[] { "203.0.113.20" }
+                        }
+                    }
+                });
+
+            _agent.Dispose();
+            _zenApiMock = ZenApiMock.CreateMock(
+                reporting: reportingApiClientMock.Object,
+                runtime: runtimeApiClientMock.Object);
+            _agent = new Agent(_zenApiMock.Object);
+
+            var lastConfigCheckField = typeof(Agent).GetField("_lastConfigCheck", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(lastConfigCheckField, Is.Not.Null);
+            lastConfigCheckField!.SetValue(_agent, DateTime.UtcNow.AddMinutes(-2).Ticks);
+
+            // Act
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while ((_agent.Context.Config.ConfigLastUpdated != 200 ||
+                    !_agent.Context.Config.GetMatchingBlockedIPListKeys("203.0.113.20").Any()) &&
+                   DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(25);
+            }
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(_agent.Context.Config.ConfigLastUpdated, Is.EqualTo(200));
+                Assert.That(
+                    _agent.Context.Config.GetMatchingBlockedIPListKeys("203.0.113.20"),
+                    Is.EquivalentTo(new[] { "recurring-test-list" }));
+            });
+        }
+
+        [Test]
         public async Task UpdateFirewallLists_WithEmptyToken_DoesNotFetchLists()
         {
             // Arrange

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -382,16 +382,23 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public void HandleHeartbeatResponse_WhenSuccessful_UpdatesConfig()
+        public void HandleHeartbeatResponse_WhenSuccessful_DoesNotUpdateConfig()
         {
-            _agent.HandleHeartbeatResponse(new ReportingAPIResponse
+            _agent.Context.Config.UpdateConfig(new ReportingAPIResponse
             {
                 Success = true,
-                ConfigUpdatedAt = 123,
+                ConfigUpdatedAt = 100,
                 Endpoints = Array.Empty<EndpointConfig>()
             });
 
-            Assert.That(_agent.Context.Config.ConfigLastUpdated, Is.EqualTo(123));
+            _agent.HandleHeartbeatResponse(new ReportingAPIResponse
+            {
+                Success = true,
+                ConfigUpdatedAt = 200,
+                Endpoints = Array.Empty<EndpointConfig>()
+            });
+
+            Assert.That(_agent.Context.Config.ConfigLastUpdated, Is.EqualTo(100));
         }
 
         [Test]

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -983,7 +983,7 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public async Task RecurringTasks_WhenRemoteConfigIsNewer_UpdatesConfigAndFirewallLists()
+        public async Task CheckConfigUpdates_WhenRemoteConfigIsNewer_UpdatesConfigAndFirewallLists()
         {
             // Arrange
             var runtimeApiClientMock = new Mock<IRuntimeAPIClient>();
@@ -1024,19 +1024,10 @@ namespace Aikido.Zen.Test
                 reporting: reportingApiClientMock.Object,
                 runtime: runtimeApiClientMock.Object);
             _agent = new Agent(_zenApiMock.Object);
-
-            var lastConfigCheckField = typeof(Agent).GetField("_lastConfigCheck", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.That(lastConfigCheckField, Is.Not.Null);
-            lastConfigCheckField!.SetValue(_agent, DateTime.UtcNow.AddMinutes(-2).Ticks);
+            _agent.LastConfigCheck = DateTime.UtcNow.AddMinutes(-2);
 
             // Act
-            var deadline = DateTime.UtcNow.AddSeconds(5);
-            while ((_agent.Context.Config.ConfigLastUpdated != 200 ||
-                    !_agent.Context.Config.GetMatchingBlockedIPListKeys("203.0.113.20").Any()) &&
-                   DateTime.UtcNow < deadline)
-            {
-                await Task.Delay(25);
-            }
+            await _agent.CheckConfigUpdates();
 
             // Assert
             Assert.Multiple(() =>

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -5,7 +5,6 @@ using Aikido.Zen.Core.Models.Events;
 using Aikido.Zen.Tests.Mocks;
 using Microsoft.Extensions.Logging;
 using Moq;
-using System.Collections.Concurrent;
 using System.Reflection;
 
 namespace Aikido.Zen.Test
@@ -383,25 +382,27 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public void Start_HeartbeatFailureCallback_LogsWarning()
+        public void HandleHeartbeatResponse_WhenSuccessful_UpdatesConfig()
+        {
+            _agent.HandleHeartbeatResponse(new ReportingAPIResponse
+            {
+                Success = true,
+                ConfigUpdatedAt = 123,
+                Endpoints = Array.Empty<EndpointConfig>()
+            });
+
+            Assert.That(_agent.Context.Config.ConfigLastUpdated, Is.EqualTo(123));
+        }
+
+        [Test]
+        public void HandleHeartbeatResponse_WhenUnsuccessful_LogsWarning()
         {
             var loggerMock = new Mock<ILogger>();
             Agent.ConfigureLogger(loggerMock.Object);
 
             try
             {
-                _agent.Start();
-
-                var scheduledEventsField = typeof(Agent).GetField("_scheduledEvents", BindingFlags.NonPublic | BindingFlags.Instance);
-                Assert.That(scheduledEventsField, Is.Not.Null);
-
-                var scheduledEvents = scheduledEventsField!.GetValue(_agent) as ConcurrentDictionary<string, Agent.ScheduledItem>;
-                Assert.That(scheduledEvents, Is.Not.Null);
-                Assert.That(scheduledEvents!.TryGetValue(Heartbeat.ScheduleId, out var scheduledItem), Is.True);
-                var callback = scheduledItem!.Callback;
-                Assert.That(callback, Is.Not.Null);
-
-                callback!(new Heartbeat(), new ReportingAPIResponse { Success = false, Error = "timeout" });
+                _agent.HandleHeartbeatResponse(new ReportingAPIResponse { Success = false, Error = "timeout" });
 
                 loggerMock.Verify(logger => logger.Log(
                     It.Is<LogLevel>(level => level == LogLevel.Warning),

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -307,7 +307,7 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public async Task Start_AppliesFirewallListsFromStartupConfig()
+        public async Task Start_FetchesAndAppliesFirewallLists()
         {
             var blockedIpList = new FirewallListsAPIResponse.IPList
             {
@@ -801,7 +801,7 @@ namespace Aikido.Zen.Test
                 Pattern = "googlebot"
             };
 
-            _agent.Context.UpdateFirewallLists(new FirewallListsAPIResponse
+            _agent.Context.Config.UpdateFirewallLists(new FirewallListsAPIResponse
             {
                 MonitoredIPAddresses = new[] { monitoredIpList },
                 MonitoredUserAgents = "googlebot",
@@ -850,7 +850,7 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public async Task ConfigChanged_WhenConfigVersionDiffers_UpdatesConfig()
+        public void ConfigChanged_WhenRemoteConfigVersionIsNewer_FetchesConfigAndReturnsTrue()
         {
             // Arrange
             var configLastUpdated = 123L;
@@ -865,8 +865,6 @@ namespace Aikido.Zen.Test
                     AllowedIPAddresses = new[] { "192.168.1.0/24" }
                 }
             };
-
-            _agent.Context.Config.ConfigLastUpdated = configLastUpdated;
 
             var configVersionResponse = new ConfigLastUpdatedAPIResponse
             {
@@ -889,10 +887,10 @@ namespace Aikido.Zen.Test
                 .ReturnsAsync(configResponse);
             _zenApiMock = ZenApiMock.CreateMock(runtime: runtimeApiClientMock.Object);
             _agent = new Agent(_zenApiMock.Object);
+            _agent.Context.Config.ConfigLastUpdated = configLastUpdated;
 
             // Act
             var result = _agent.ConfigChanged(out var response);
-            await Task.Delay(100);
 
             // Assert
             Assert.Multiple(() =>
@@ -902,47 +900,39 @@ namespace Aikido.Zen.Test
                 Assert.That(response.ConfigUpdatedAt, Is.EqualTo(newConfigLastUpdated));
                 Assert.That(response.BlockedUserIds, Is.EquivalentTo(blockedUsers));
                 Assert.That(response.Endpoints, Is.EquivalentTo(endpoints));
+                Assert.That(_agent.Context.Config.ConfigLastUpdated, Is.EqualTo(configLastUpdated));
             });
 
             _zenApiMock.Verify(x => x.Runtime.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
             _zenApiMock.Verify(x => x.Runtime.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
-        [Test]
-        public async Task ConfigChanged_WhenConfigVersionSame_ReturnsFalse()
+        [TestCase(123L, 123L)]
+        [TestCase(124L, 123L)]
+        public void ConfigChanged_WhenRemoteConfigVersionIsNotNewer_ReturnsFalse(long localConfigLastUpdated, long remoteConfigLastUpdated)
         {
             // Arrange
-            var configLastUpdated = 123L;
-
             var configVersionResponse = new ConfigLastUpdatedAPIResponse
             {
                 Success = true,
-                ConfigUpdatedAt = configLastUpdated,
-            };
-            var configResponse = new ReportingAPIResponse
-            {
-                Success = true,
-                ConfigUpdatedAt = configLastUpdated,
+                ConfigUpdatedAt = remoteConfigLastUpdated,
             };
             var runtimeApiClientMock = new Mock<IRuntimeAPIClient>();
             runtimeApiClientMock.Setup(x => x.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(configVersionResponse);
-            runtimeApiClientMock.Setup(x => x.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(configResponse);
             _zenApiMock = ZenApiMock.CreateMock(runtime: runtimeApiClientMock.Object);
             _agent = new Agent(_zenApiMock.Object);
-            _agent.Context.Config.ConfigLastUpdated = configLastUpdated;
+            _agent.Context.Config.ConfigLastUpdated = localConfigLastUpdated;
 
             // Act
             var result = _agent.ConfigChanged(out var response);
-            await Task.Delay(100);
 
             // Assert
             Assert.Multiple(() =>
             {
                 Assert.That(result, Is.False);
                 Assert.That(response.Success, Is.True);
-                Assert.That(response.ConfigUpdatedAt, Is.EqualTo(configLastUpdated));
+                Assert.That(response.ConfigUpdatedAt, Is.EqualTo(remoteConfigLastUpdated));
             });
 
             _zenApiMock.Verify(x => x.Runtime.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -950,7 +940,7 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public async Task ConfigChanged_WhenConfigFetchFails_ReturnsFalse()
+        public void ConfigChanged_WhenConfigFetchFails_ReturnsFalse()
         {
             // Arrange
             var configLastUpdated = 123L;
@@ -979,7 +969,6 @@ namespace Aikido.Zen.Test
 
             // Act
             var result = _agent.ConfigChanged(out var response);
-            await Task.Delay(100);
 
             // Assert
             Assert.Multiple(() =>
@@ -994,7 +983,7 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public async Task UpdateBlockedIps_WithEmptyToken_ReturnsWithoutUpdating()
+        public async Task UpdateFirewallLists_WithEmptyToken_DoesNotFetchLists()
         {
             // Arrange
             Environment.SetEnvironmentVariable("AIKIDO_TOKEN", "");

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -984,7 +984,7 @@ namespace Aikido.Zen.Test
         }
 
         [Test]
-        public async Task CheckConfigUpdates_WhenRemoteConfigIsNewer_UpdatesConfigAndFirewallLists()
+        public async Task RecurringTasks_WhenConfigCheckIsDueAndRemoteConfigIsNewer_UpdatesConfig()
         {
             // Arrange
             var runtimeApiClientMock = new Mock<IRuntimeAPIClient>();
@@ -1004,40 +1004,23 @@ namespace Aikido.Zen.Test
                     ConfigUpdatedAt = 200
                 });
 
-            var reportingApiClientMock = new Mock<IReportingAPIClient>();
-            reportingApiClientMock
-                .Setup(x => x.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new FirewallListsAPIResponse
-                {
-                    Success = true,
-                    BlockedIPAddresses = new[]
-                    {
-                        new FirewallListsAPIResponse.IPList
-                        {
-                            Key = "recurring-test-list",
-                            Ips = new[] { "203.0.113.20" }
-                        }
-                    }
-                });
-
             _agent.Dispose();
             _zenApiMock = ZenApiMock.CreateMock(
-                reporting: reportingApiClientMock.Object,
                 runtime: runtimeApiClientMock.Object);
             _agent = new Agent(_zenApiMock.Object);
             _agent.LastConfigCheck = DateTime.UtcNow.AddMinutes(-2);
 
             // Act
-            await _agent.CheckConfigUpdates();
+            await Task.Delay(1000);
 
             // Assert
             Assert.Multiple(() =>
             {
                 Assert.That(_agent.Context.Config.ConfigLastUpdated, Is.EqualTo(200));
-                Assert.That(
-                    _agent.Context.Config.GetMatchingBlockedIPListKeys("203.0.113.20"),
-                    Is.EquivalentTo(new[] { "recurring-test-list" }));
             });
+
+            _zenApiMock.Verify(x => x.Runtime.GetConfigLastUpdated(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            _zenApiMock.Verify(x => x.Runtime.GetConfig(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]

--- a/Aikido.Zen.Test/Concurrency.AgentContextTests.cs
+++ b/Aikido.Zen.Test/Concurrency.AgentContextTests.cs
@@ -155,7 +155,7 @@ namespace Aikido.Zen.Test
                         allEndpoints.TryAdd(key, config);
 
                         var endpoints = new List<EndpointConfig> { config };
-                        _agentContext.UpdateRatelimitedRoutes(endpoints);
+                        _agentContext.Config.UpdateRatelimitedRoutes(endpoints);
                     }
                 });
                 threads.Add(thread);
@@ -171,7 +171,7 @@ namespace Aikido.Zen.Test
             // Assert - we should have at least one endpoint from each thread
             // Due to the nature of parallel updates, we can't guarantee exactly which ones will be there
             // But we can verify that the collection is consistent and doesn't crash
-            var finalEndpoints = _agentContext.Endpoints.ToList();
+            var finalEndpoints = _agentContext.Config.Endpoints.ToList();
             Assert.That(finalEndpoints, Is.Not.Null);
             Assert.That(finalEndpoints.Count, Is.GreaterThan(0));
             Assert.That(finalEndpoints.Count, Is.LessThanOrEqualTo(numThreads * numEndpointsPerThread));
@@ -228,7 +228,7 @@ namespace Aikido.Zen.Test
                                 }
                             }
                         };
-                        _agentContext.UpdateRatelimitedRoutes(endpoints);
+                        _agentContext.Config.UpdateRatelimitedRoutes(endpoints);
                     }
                 });
                 threads.Add(thread);
@@ -250,7 +250,7 @@ namespace Aikido.Zen.Test
 
                 // Since many threads are updating the endpoints list, we can't guarantee exactly how many will be there,
                 // but we can verify it's a consistent state
-                var finalEndpoints = _agentContext.Endpoints.ToList();
+                var finalEndpoints = _agentContext.Config.Endpoints.ToList();
                 Assert.That(finalEndpoints, Is.Not.Null);
                 Assert.That(finalEndpoints.Count, Is.GreaterThan(0));
                 Assert.That(finalEndpoints.Count, Is.LessThanOrEqualTo(numThreads * numOperationsPerThread));

--- a/Aikido.Zen.Test/ReportingAPIResponseTests.cs
+++ b/Aikido.Zen.Test/ReportingAPIResponseTests.cs
@@ -16,6 +16,10 @@ namespace Aikido.Zen.Test
             // Assert
             Assert.That(response, Is.Not.Null);
             Assert.That(response.Success, Is.False);
+            Assert.That(response.Endpoints, Is.Null);
+            Assert.That(response.BlockedUserIds, Is.Null);
+            Assert.That(response.ExcludedUserIdsFromRateLimiting, Is.Null);
+            Assert.That(response.BypassedIPAddresses, Is.Null);
         }
 
         [Test]

--- a/Aikido.Zen.Tests.DotNetCore/BlockingMiddlewareTests.cs
+++ b/Aikido.Zen.Tests.DotNetCore/BlockingMiddlewareTests.cs
@@ -78,7 +78,7 @@ namespace Aikido.Zen.Tests.DotNetCore
                 RateLimitingHelper.ResetCache(10000, 120 * 60 * 1000);
                 Agent.Instance.Context.Config.Clear();
                 Agent.Instance.ClearContext();
-                Agent.Instance.Context.UpdateRatelimitedRoutes(new[]
+                Agent.Instance.Context.Config.UpdateRatelimitedRoutes(new[]
                 {
                     new EndpointConfig
                     {

--- a/Aikido.Zen.Tests.DotNetCore/ContextMiddlewareTests.cs
+++ b/Aikido.Zen.Tests.DotNetCore/ContextMiddlewareTests.cs
@@ -95,7 +95,7 @@ namespace Aikido.Zen.Tests.DotNetCore
                 Environment.SetEnvironmentVariable("AIKIDO_DISABLE", "false");
                 Agent.Instance.Context.Config.Clear();
                 Agent.Instance.ClearContext();
-                Agent.Instance.Context.BlockList.UpdateBypassedIps(new[] { bypassedIp });
+                Agent.Instance.Context.Config.BlockList.UpdateBypassedIps(new[] { bypassedIp });
 
                 await _contextMiddleware.InvokeAsync(context, next);
 

--- a/Aikido.Zen.Tests.DotNetFramework/BlockingModuleTests.cs
+++ b/Aikido.Zen.Tests.DotNetFramework/BlockingModuleTests.cs
@@ -63,7 +63,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
         public void HandleBlocking_BlocksRequest_WhenContextUserIsBlocked()
         {
             Agent.Instance.ClearContext();
-            Agent.Instance.Context.UpdateBlockedUsers(new[] { "blocked-user" });
+            Agent.Instance.Context.Config.UpdateBlockedUsers(new[] { "blocked-user" });
 
             try
             {
@@ -101,7 +101,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
             finally
             {
                 Agent.Instance.ClearContext();
-                Agent.Instance.Context.UpdateBlockedUsers(System.Array.Empty<string>());
+                Agent.Instance.Context.Config.UpdateBlockedUsers(System.Array.Empty<string>());
             }
         }
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated startup flow to fetch firewall lists after initial config application

**🐛 Bugfixes**
* Stopped applying configuration updates from heartbeat responses to prevent races
* Made ReportingAPIResponse fields nullable to support partial config updates

**🔧 Refactors**
* Refactored config access to AgentContext.Config and updated call sites
* Converted Agent last config check to DateTime property and exposed it


<sup>[More info](https://app.aikido.dev/featurebranch/scan/133046387?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->