### PR TITLE
Use AsyncLocal context in .NET Framework (fixes SSRF)

### DIFF
--- a/Aikido.Zen.Core/Sinks/Inspector.cs
+++ b/Aikido.Zen.Core/Sinks/Inspector.cs
@@ -17,6 +17,15 @@ namespace Aikido.Zen.Core.Sinks
             string operationKind,
             Func<Context, InspectionResult> inspect)
         {
+            return Inspect(originalMethod, operationKind, null, inspect);
+        }
+
+        internal static bool Inspect(
+            MethodBase originalMethod,
+            string operationKind,
+            Context contextOverride,
+            Func<Context, InspectionResult> inspect)
+        {
             if (IsInspecting.Value)
             {
                 return true;
@@ -26,7 +35,7 @@ namespace Aikido.Zen.Core.Sinks
 
             try
             {
-                var context = Patcher.GetContext();
+                var context = contextOverride ?? Patcher.GetContext();
 
                 try
                 {

--- a/Aikido.Zen.Core/Sinks/OutboundRequestInnerSink.cs
+++ b/Aikido.Zen.Core/Sinks/OutboundRequestInnerSink.cs
@@ -21,9 +21,10 @@ namespace Aikido.Zen.Core.Sinks
         [SinkPrefix("System.Net.Http", "System.Net.Http.Http3Connection", "SendAsync", "System.Net.Http.HttpRequestMessage", "System.Int64", "System.Threading.CancellationToken")]
         [SinkPrefix("System.Net.Http", "System.Net.Http.Http3Connection", "SendAsync", "System.Net.Http.HttpRequestMessage", "System.Int64", "System.Diagnostics.Activity", "System.Threading.CancellationToken")]
         [SinkPrefix("System.Net.Http", "System.Net.Http.Http3Connection", "SendAsync", "System.Net.Http.HttpRequestMessage", "System.Net.Http.Http3Connection+WaitForHttp3ConnectionActivity", "System.Boolean", "System.Threading.CancellationToken")]
-        internal static bool OnRequest(object __instance, MethodBase __originalMethod, ref Task<HttpResponseMessage> __result)
+        internal static bool OnRequest(HttpRequestMessage request, object __instance, MethodBase __originalMethod, ref Task<HttpResponseMessage> __result)
         {
-            if (!OutboundRequestSink.TryGetCurrentRequestUri(out var targetUri))
+            var targetUri = request?.RequestUri;
+            if (targetUri == null)
             {
                 return true;
             }
@@ -43,21 +44,24 @@ namespace Aikido.Zen.Core.Sinks
             }
             catch (AikidoException ex)
             {
-                OutboundRequestSink.SetDetectedException(ex);
                 __result = Task.FromException<HttpResponseMessage>(ex);
                 return false;
             }
         }
 
         [SinkPrefix("System", "System.Net.ConnectStream", "WriteHeaders", "System.Boolean")]
-        internal static bool OnFrameworkRequest(object ___m_Connection, MethodBase __originalMethod)
+        internal static bool OnFrameworkRequest(object __instance, object ___m_Connection, MethodBase __originalMethod)
         {
-            if (!OutboundRequestSink.TryGetCurrentRequestUri(out var targetUri))
+            var request = ReflectionHelper.GetMemberValue(__instance, "m_Request") as HttpWebRequest;
+            OutboundRequestSink.TryGetTrackedRequest(request, out var state);
+            var targetUri = state?.TargetUri ?? request?.RequestUri;
+            var remoteAddress = GetIPAddressFromStream(ReflectionHelper.GetMemberValue(___m_Connection, "NetworkStream") as Stream);
+
+            if (targetUri == null)
             {
                 return true;
             }
 
-            var remoteAddress = GetIPAddressFromStream(ReflectionHelper.GetMemberValue(___m_Connection, "NetworkStream") as Stream);
             if (remoteAddress == null)
             {
                 return true;
@@ -68,11 +72,17 @@ namespace Aikido.Zen.Core.Sinks
                 return Inspector.Inspect(
                     __originalMethod,
                     OperationKind,
+                    state?.Context,
                     context => SSRFDetector.Detect(targetUri, remoteAddress, context));
             }
             catch (AikidoException ex)
             {
-                OutboundRequestSink.SetDetectedException(ex);
+                if (state != null)
+                {
+                    state.DetectedException = ex;
+                }
+
+                request?.Abort();
                 throw;
             }
         }

--- a/Aikido.Zen.Core/Sinks/OutboundRequestSink.cs
+++ b/Aikido.Zen.Core/Sinks/OutboundRequestSink.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
-using System.Threading;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Aikido.Zen.Core.Exceptions;
 using Aikido.Zen.Core.Helpers;
@@ -14,7 +14,10 @@ namespace Aikido.Zen.Core.Sinks
     internal static class OutboundRequestSink
     {
         private const string OperationKind = "outgoing_http_op";
-        private static readonly AsyncLocal<OutboundRequest> CurrentRequest = new AsyncLocal<OutboundRequest>();
+        // .NET Framework writes headers after HttpContext.Current is no longer available,
+        // so keep the request context attached to the outbound request object.
+        private static readonly ConditionalWeakTable<object, OutboundRequestState> Requests = new ConditionalWeakTable<object, OutboundRequestState>();
+        private static readonly object RequestLock = new object();
 
         [SinkPrefix(typeof(HttpClient), "SendAsync", "System.Net.Http.HttpRequestMessage")]
         [SinkPrefix(typeof(HttpClient), "SendAsync", "System.Net.Http.HttpRequestMessage", "System.Net.Http.HttpCompletionOption")]
@@ -26,10 +29,32 @@ namespace Aikido.Zen.Core.Sinks
         [SinkPrefix(typeof(HttpClient), "Send", "System.Net.Http.HttpRequestMessage", "System.Threading.CancellationToken")]
         internal static bool OnRequestHttpClient(HttpRequestMessage request, HttpClient __instance, MethodBase __originalMethod)
         {
+            var targetUri = ResolveUri(request, __instance);
+            TrackRequest(request, targetUri);
             return Inspector.Inspect(
                 __originalMethod,
                 OperationKind,
-                context => OnRequest(ResolveUri(request, __instance), context));
+                context => OnRequest(targetUri, context));
+        }
+
+        [SinkPostfix("System.Net.Http", "System.Net.Http.HttpClientHandler", "CreateAndPrepareWebRequest", "System.Net.Http.HttpRequestMessage")]
+        internal static void OnHttpClientWebRequestCreated(HttpRequestMessage request, HttpWebRequest __result)
+        {
+            AssociateRequest(request, __result);
+        }
+
+        [SinkFinalizer(typeof(HttpClient), "SendAsync", "System.Net.Http.HttpRequestMessage")]
+        [SinkFinalizer(typeof(HttpClient), "SendAsync", "System.Net.Http.HttpRequestMessage", "System.Net.Http.HttpCompletionOption")]
+        [SinkFinalizer(typeof(HttpClient), "SendAsync", "System.Net.Http.HttpRequestMessage", "System.Net.Http.HttpCompletionOption", "System.Threading.CancellationToken")]
+        [SinkFinalizer(typeof(HttpClient), "SendAsync", "System.Net.Http.HttpRequestMessage", "System.Threading.CancellationToken")]
+        internal static Exception OnHttpClientRequestFinalized(HttpRequestMessage request, ref Task<HttpResponseMessage> __result, Exception __exception)
+        {
+            if (__result != null && TryGetTrackedRequest(request, out var state))
+            {
+                __result = ThrowDetectedException(__result, state);
+            }
+
+            return __exception;
         }
 
         [SinkPrefix(typeof(WebRequest), "GetResponse")]
@@ -38,39 +63,31 @@ namespace Aikido.Zen.Core.Sinks
         [SinkPrefix(typeof(HttpWebRequest), "GetResponseAsync")]
         internal static bool OnRequestWebRequest(WebRequest __instance, MethodBase __originalMethod)
         {
+            TrackRequest(__instance, __instance?.RequestUri);
             return Inspector.Inspect(
                 __originalMethod,
                 OperationKind,
                 context => OnRequest(__instance?.RequestUri, context));
         }
 
-        [SinkFinalizer]
-        internal static Exception OnRequestFinalized(ref object __result, Exception __exception)
+        [SinkFinalizer(typeof(WebRequest), "GetResponseAsync")]
+        [SinkFinalizer(typeof(HttpWebRequest), "GetResponseAsync")]
+        internal static Exception OnWebRequestFinalized(WebRequest __instance, ref Task<WebResponse> __result, Exception __exception)
         {
-            if (__result is Task<HttpResponseMessage> responseTask && CurrentRequest.Value != null)
+            if (__result != null && TryGetTrackedRequest(__instance, out var state))
             {
-                __result = ThrowDetectedException(responseTask, CurrentRequest.Value);
+                __result = ThrowDetectedException(__result, state);
             }
 
-            ExitRequestScope();
             return __exception;
         }
 
         private static InspectionResult OnRequest(Uri targetUri, Context context)
         {
-            // Modern WebRequest wraps HttpClient, so the inner HttpClient hook
-            // should not replace the original request URI or report stats twice.
-            if (TryGetCurrentRequestUri(out _))
-            {
-                return InspectionResult.Allow(skipStats: true);
-            }
-
             if (targetUri == null)
             {
                 return InspectionResult.Allow(skipStats: true);
             }
-
-            EnterRequestScope(targetUri);
 
             var hostname = targetUri.Host;
             var port = UriHelper.GetPort(targetUri);
@@ -106,56 +123,68 @@ namespace Aikido.Zen.Core.Sinks
             return new Uri(client.BaseAddress, request.RequestUri);
         }
 
-        private static void EnterRequestScope(Uri targetUri)
+        internal static bool TryGetTrackedRequest(object request, out OutboundRequestState state)
         {
-            ExitRequestScope();
+            state = null;
+            return request != null && Requests.TryGetValue(request, out state);
+        }
 
-            if (targetUri != null)
+        private static void TrackRequest(object request, Uri targetUri)
+        {
+            if (request == null || targetUri == null)
             {
-                CurrentRequest.Value = new OutboundRequest(targetUri);
+                return;
+            }
+
+            var state = new OutboundRequestState(targetUri, Patcher.GetContext());
+            lock (RequestLock)
+            {
+                Requests.Remove(request);
+                Requests.Add(request, state);
             }
         }
 
-        internal static void ExitRequestScope()
+        private static void AssociateRequest(object sourceRequest, object targetRequest)
         {
-            CurrentRequest.Value = null;
-        }
-
-        internal static bool TryGetCurrentRequestUri(out Uri targetUri)
-        {
-            targetUri = CurrentRequest.Value?.TargetUri;
-            return targetUri != null;
-        }
-
-        internal static void SetDetectedException(AikidoException exception)
-        {
-            var currentRequest = CurrentRequest.Value;
-            if (currentRequest != null)
+            if (sourceRequest == null || targetRequest == null)
             {
-                currentRequest.DetectedException = exception;
+                return;
+            }
+
+            if (!Requests.TryGetValue(sourceRequest, out var state))
+            {
+                return;
+            }
+
+            lock (RequestLock)
+            {
+                Requests.Remove(targetRequest);
+                Requests.Add(targetRequest, state);
             }
         }
 
-        private static async Task<HttpResponseMessage> ThrowDetectedException(Task<HttpResponseMessage> responseTask, OutboundRequest request)
+        private static async Task<T> ThrowDetectedException<T>(Task<T> responseTask, OutboundRequestState state)
         {
             try
             {
                 return await responseTask.ConfigureAwait(false);
             }
-            catch (Exception) when (request.DetectedException != null)
+            catch (Exception) when (state?.DetectedException != null)
             {
-                throw request.DetectedException;
+                throw state.DetectedException;
             }
         }
 
-        private sealed class OutboundRequest
+        internal sealed class OutboundRequestState
         {
-            internal OutboundRequest(Uri targetUri)
+            internal OutboundRequestState(Uri targetUri, Context context)
             {
                 TargetUri = targetUri;
+                Context = context;
             }
 
             internal Uri TargetUri { get; }
+            internal Context Context { get; }
             internal AikidoException DetectedException { get; set; }
         }
     }

--- a/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
@@ -34,7 +34,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
             try
             {
                 LogHelper.DebugLog(Agent.Logger, "Checking if request needs to be blocked");
-                var aikidoContext = (Context)httpContext.Items["Aikido.Zen.Context"];
+                var aikidoContext = Zen.GetContext();
                 var agentContext = Agent.Instance.Context;
 
                 Agent.Instance.SetBlockingMiddlewareInstalled(true);

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -34,12 +34,9 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
             responseHandled = false;
             LogHelper.DebugLog(Agent.Logger, "ContextModule initialized");
             context.PostAuthenticateRequest += Context_PostAuthenticateRequest;
-            // we add the .Wait(), because we want our module to handle exceptions properly
-            context.BeginRequest += (sender, e) => Task.Run(() => Context_BeginRequest(sender, e)).Wait();
-            // we try to discover the route as early as possible (we just need a statuscode), but we fallback to other listeners in case some are skipped.
-            context.PreSendRequestHeaders += Context_EndRequest;
+            // Capture request context before application handlers run.
+            context.BeginRequest += Context_BeginRequest;
             context.EndRequest += Context_EndRequest;
-            context.PostRequestHandlerExecute += Context_EndRequest;
         }
 
         private void Context_PostAuthenticateRequest(object sender, EventArgs e)
@@ -51,7 +48,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
 
         internal static void PopulateAuthenticatedUser(HttpContext httpContext)
         {
-            var aikidoContext = (Context)httpContext.Items["Aikido.Zen.Context"];
+            var aikidoContext = Zen.GetContext();
 
             if (Context.IsNullOrBypassed(aikidoContext))
             {
@@ -69,7 +66,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
 
         internal static void PopulateRateLimitGroup(HttpContext httpContext)
         {
-            var aikidoContext = (Context)httpContext.Items["Aikido.Zen.Context"];
+            var aikidoContext = Zen.GetContext();
 
             if (Context.IsNullOrBypassed(aikidoContext))
             {
@@ -83,7 +80,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
             }
         }
 
-        private async Task Context_BeginRequest(object sender, EventArgs e)
+        private void Context_BeginRequest(object sender, EventArgs e)
         {
             LogHelper.DebugLog(Agent.Logger, "Capturing request context");
             var httpContext = ((HttpApplication)sender).Context;
@@ -94,13 +91,15 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
 
                 if (EnvironmentHelper.IsDisabled)
                 {
+                    Zen.SetCurrentContext(null);
                     return;
                 }
 
                 // Store bypass marker context so patches can still honor bypass
                 if (Agent.Instance.Context.Config.BlockList.IsIPBypassed(clientIp))
                 {
-                    httpContext.Items["Aikido.Zen.Context"] = new Context { Bypassed = true };
+                    var bypassedContext = new Context { Bypassed = true };
+                    Zen.SetCurrentContext(bypassedContext);
                     return;
                 }
 
@@ -124,25 +123,26 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
 
                 var request = httpContext.Request;
 
-                var httpData = await HttpHelper.ReadAndFlattenHttpDataAsync(
+                var httpData = Task.Run(() => HttpHelper.ReadAndFlattenHttpDataAsync(
                     routeParams: context.RouteParams,
                     queryParams: context.Query,
                     headers: request.Headers.AllKeys.ToDictionary(k => k, k => request.Headers.Get(k)),
                     cookies: request.Cookies.AllKeys.ToDictionary(k => k, k => request.Cookies[k].Value),
                     body: request.InputStream,
                     contentType: request.ContentType
-                );
+                )).GetAwaiter().GetResult();
 
                 context.ParsedUserInput = httpData.FlattenedData;
                 context.Body = request.InputStream;
                 context.ParsedBody = httpData.ParsedBody;
                 Agent.Instance.CaptureRequestUser(context);
-                httpContext.Items["Aikido.Zen.Context"] = context;
+                Zen.SetCurrentContext(context);
             }
             catch (Exception ex)
             {
                 // pass through
                 LogHelper.ErrorLog(Agent.Logger, $"Error capturing request {ex.Message}");
+                Zen.SetCurrentContext(null);
             }
             finally
             {
@@ -161,7 +161,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                 }
 
                 var httpContext = ((HttpApplication)sender).Context;
-                var aikidoContext = (Context)httpContext.Items["Aikido.Zen.Context"];
+                var aikidoContext = Zen.GetContext();
                 if (aikidoContext == null)
                 {
                     LogHelper.DebugLog(Agent.Logger, "Aikido context is null, skipping route");
@@ -192,6 +192,10 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
             catch (Exception ex)
             {
                 LogHelper.ErrorLog(Agent.Logger, $"Error adding route: {ex.Message}");
+            }
+            finally
+            {
+                Zen.ClearCurrentContext();
             }
         }
 

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -32,9 +32,11 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
         {
             responseHandled = false;
             LogHelper.DebugLog(Agent.Logger, "ContextModule initialized");
-            context.PostAuthenticateRequest += Context_PostAuthenticateRequest;
-            // Capture request context before application handlers run.
+            // BeginRequest is the earliest reliable hook once a request enters the pipeline
             context.BeginRequest += Context_BeginRequest;
+            // User information is only available after authentication, although this stage can be skipped
+            context.PostAuthenticateRequest += Context_PostAuthenticateRequest;
+            // EndRequest is the reliable final hook, including requests completed early
             context.EndRequest += Context_EndRequest;
         }
 
@@ -234,7 +236,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                 // Replace with empty string to avoid exceptions
                 var safeKey = key ?? string.Empty;
                 var values = queryString.GetValues(key);
-                
+
                 // Example: for ?foo=a&foo=b, the dictionary will be:
                 // { "foo": "a", "foo[1]": "b" }
                 // The first value ("a") is used as the default ("foo"), matching ASP.NET Core's default behavior for query and header collections.

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -26,11 +26,8 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
             // Nothing to dispose
         }
 
-        private bool responseHandled = false;
-
         public void Init(HttpApplication context)
         {
-            responseHandled = false;
             LogHelper.DebugLog(Agent.Logger, "ContextModule initialized");
             // BeginRequest is the earliest reliable hook once a request enters the pipeline
             context.BeginRequest += Context_BeginRequest;
@@ -87,7 +84,6 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
             var httpContext = ((HttpApplication)sender).Context;
             try
             {
-                responseHandled = false;
                 string clientIp = GetClientIp(httpContext);
 
                 if (EnvironmentHelper.IsDisabled)
@@ -156,11 +152,6 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
         {
             try
             {
-                if (responseHandled)
-                {
-                    return;
-                }
-
                 var httpContext = ((HttpApplication)sender).Context;
                 var aikidoContext = Zen.GetContext();
                 if (aikidoContext == null)
@@ -171,10 +162,8 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                 if (Context.IsBypassed(aikidoContext))
                 {
                     LogHelper.DebugLog(Agent.Logger, "Aikido context is bypassed, skipping route");
-                    responseHandled = true;
                     return;
                 }
-                responseHandled = true;
 
                 int statusCode = httpContext.Response.StatusCode;
                 var attackWaveDetector = Agent.Instance.AttackWaveDetector;

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using System.Web;
 using System.Web.Routing;
 using Aikido.Zen.Core;
@@ -123,14 +122,14 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
 
                 var request = httpContext.Request;
 
-                var httpData = Task.Run(() => HttpHelper.ReadAndFlattenHttpDataAsync(
+                var httpData = HttpHelper.ReadAndFlattenHttpDataAsync(
                     routeParams: context.RouteParams,
                     queryParams: context.Query,
                     headers: request.Headers.AllKeys.ToDictionary(k => k, k => request.Headers.Get(k)),
                     cookies: request.Cookies.AllKeys.ToDictionary(k => k, k => request.Cookies[k].Value),
                     body: request.InputStream,
                     contentType: request.ContentType
-                )).GetAwaiter().GetResult();
+                ).GetAwaiter().GetResult();
 
                 context.ParsedUserInput = httpData.FlattenedData;
                 context.Body = request.InputStream;

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -89,7 +89,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
 
                 if (EnvironmentHelper.IsDisabled)
                 {
-                    Zen.SetCurrentContext(null);
+                    Zen.ClearCurrentContext();
                     return;
                 }
 
@@ -142,7 +142,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
             {
                 // pass through
                 LogHelper.ErrorLog(Agent.Logger, $"Error capturing request {ex.Message}");
-                Zen.SetCurrentContext(null);
+                Zen.ClearCurrentContext();
             }
             finally
             {

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Web;
 using System.Web.Routing;
 using Aikido.Zen.Core;
@@ -120,14 +121,16 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
 
                 var request = httpContext.Request;
 
-                var httpData = HttpHelper.ReadAndFlattenHttpDataAsync(
+                // Use Task.Run because waiting directly on async work can deadlock
+                // when awaits resume on the ASP.NET request context used by BeginRequest.
+                var httpData = Task.Run(() => HttpHelper.ReadAndFlattenHttpDataAsync(
                     routeParams: context.RouteParams,
                     queryParams: context.Query,
                     headers: request.Headers.AllKeys.ToDictionary(k => k, k => request.Headers.Get(k)),
                     cookies: request.Cookies.AllKeys.ToDictionary(k => k, k => request.Cookies[k].Value),
                     body: request.InputStream,
                     contentType: request.ContentType
-                ).GetAwaiter().GetResult();
+                )).GetAwaiter().GetResult();
 
                 context.ParsedUserInput = httpData.FlattenedData;
                 context.Body = request.InputStream;

--- a/Aikido.Zen.DotNetFramework/Zen.cs
+++ b/Aikido.Zen.DotNetFramework/Zen.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Web;
 using Aikido.Zen.Core;
 using Aikido.Zen.Core.Api;
@@ -16,6 +17,7 @@ namespace Aikido.Zen.DotNetFramework
     {
         // we need to reference Harmony somewhere to ensure it is copied with our package
         private static HarmonyLib.Harmony harmony = new HarmonyLib.Harmony("reference");
+        private static readonly AsyncLocal<Context> CurrentContext = new AsyncLocal<Context>();
         public static void Start()
         {
             // libzen_internals only available on 64
@@ -85,7 +87,7 @@ namespace Aikido.Zen.DotNetFramework
 
         public static Context GetContext()
         {
-            return (Context)HttpContext.Current?.Items["Aikido.Zen.Context"];
+            return CurrentContext.Value;
         }
 
         public static User GetUser()
@@ -127,6 +129,15 @@ namespace Aikido.Zen.DotNetFramework
             }
         }
 
+        internal static void SetCurrentContext(Context context)
+        {
+            CurrentContext.Value = context;
+        }
+
+        internal static void ClearCurrentContext()
+        {
+            CurrentContext.Value = null;
+        }
 
         public static void Init()
         {

--- a/Aikido.Zen.DotNetFramework/Zen.cs
+++ b/Aikido.Zen.DotNetFramework/Zen.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
 using System.Web;
 using Aikido.Zen.Core;
 using Aikido.Zen.Core.Api;
@@ -17,7 +16,7 @@ namespace Aikido.Zen.DotNetFramework
     {
         // we need to reference Harmony somewhere to ensure it is copied with our package
         private static HarmonyLib.Harmony harmony = new HarmonyLib.Harmony("reference");
-        private static readonly AsyncLocal<Context> CurrentContext = new AsyncLocal<Context>();
+        private const string ContextItemKey = "Aikido.Zen.DotNetFramework.Context";
         public static void Start()
         {
             // libzen_internals only available on 64
@@ -87,7 +86,7 @@ namespace Aikido.Zen.DotNetFramework
 
         public static Context GetContext()
         {
-            return CurrentContext.Value;
+            return HttpContext.Current?.Items[ContextItemKey] as Context;
         }
 
         public static User GetUser()
@@ -131,12 +130,24 @@ namespace Aikido.Zen.DotNetFramework
 
         internal static void SetCurrentContext(Context context)
         {
-            CurrentContext.Value = context;
+            var current = HttpContext.Current;
+            if (current == null)
+            {
+                return;
+            }
+
+            if (context == null)
+            {
+                current.Items.Remove(ContextItemKey);
+                return;
+            }
+
+            current.Items[ContextItemKey] = context;
         }
 
         internal static void ClearCurrentContext()
         {
-            CurrentContext.Value = null;
+            HttpContext.Current?.Items.Remove(ContextItemKey);
         }
 
         public static void Init()

--- a/Aikido.Zen.DotNetFramework/Zen.cs
+++ b/Aikido.Zen.DotNetFramework/Zen.cs
@@ -136,12 +136,6 @@ namespace Aikido.Zen.DotNetFramework
                 return;
             }
 
-            if (context == null)
-            {
-                current.Items.Remove(ContextItemKey);
-                return;
-            }
-
             current.Items[ContextItemKey] = context;
         }
 

--- a/Aikido.Zen.Tests.DotNetFramework/BlockingModuleTests.cs
+++ b/Aikido.Zen.Tests.DotNetFramework/BlockingModuleTests.cs
@@ -7,6 +7,7 @@ using Aikido.Zen.Core.Models;
 using Aikido.Zen.DotNetFramework;
 using Aikido.Zen.DotNetFramework.HttpModules;
 using NUnit.Framework;
+using FrameworkZen = Aikido.Zen.DotNetFramework.Zen;
 
 namespace Aikido.Zen.Tests.DotNetFramework
 {
@@ -81,7 +82,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
                     RemoteAddress = "127.0.0.1",
                     User = user
                 };
-                httpContext.Items["Aikido.Zen.Context"] = aikidoContext;
+                FrameworkZen.SetCurrentContext(aikidoContext);
                 var completed = false;
 
                 BlockingModule.HandleBlocking(httpContext, () => completed = true);
@@ -102,6 +103,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
             {
                 Agent.Instance.ClearContext();
                 Agent.Instance.Context.Config.UpdateBlockedUsers(System.Array.Empty<string>());
+                FrameworkZen.ClearCurrentContext();
             }
         }
 
@@ -127,7 +129,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
                     new HttpRequest(string.Empty, "http://test.local/api/test", string.Empty),
                     new HttpResponse(new StringWriter()));
                 HttpContext.Current = httpContext;
-                httpContext.Items["Aikido.Zen.Context"] = new Context
+                FrameworkZen.SetCurrentContext(new Context
                 {
                     Url = "http://test.local/api/test",
                     Path = "/api/test",
@@ -135,13 +137,14 @@ namespace Aikido.Zen.Tests.DotNetFramework
                     Route = "/api/test",
                     RemoteAddress = "127.0.0.1",
                     User = user
-                };
+                });
 
                 Assert.That(Aikido.Zen.DotNetFramework.Zen.GetUser(), Is.SameAs(user));
             }
             finally
             {
                 HttpContext.Current = originalCurrent;
+                FrameworkZen.ClearCurrentContext();
             }
         }
 

--- a/Aikido.Zen.Tests.DotNetFramework/BlockingModuleTests.cs
+++ b/Aikido.Zen.Tests.DotNetFramework/BlockingModuleTests.cs
@@ -65,6 +65,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
         {
             Agent.Instance.ClearContext();
             Agent.Instance.Context.Config.UpdateBlockedUsers(new[] { "blocked-user" });
+            var originalCurrent = HttpContext.Current;
 
             try
             {
@@ -82,6 +83,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
                     RemoteAddress = "127.0.0.1",
                     User = user
                 };
+                HttpContext.Current = httpContext;
                 FrameworkZen.SetCurrentContext(aikidoContext);
                 var completed = false;
 
@@ -104,6 +106,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
                 Agent.Instance.ClearContext();
                 Agent.Instance.Context.Config.UpdateBlockedUsers(System.Array.Empty<string>());
                 FrameworkZen.ClearCurrentContext();
+                HttpContext.Current = originalCurrent;
             }
         }
 

--- a/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
+++ b/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
@@ -295,7 +295,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
                     Route = "/api/test",
                     RemoteAddress = "127.0.0.1"
                 };
-                httpContext.Items["Aikido.Zen.Context"] = aikidoContext;
+                Aikido.Zen.DotNetFramework.Zen.SetCurrentContext(aikidoContext);
                 Aikido.Zen.DotNetFramework.Zen.SetUserAction = _ => user;
 
                 ContextModule.PopulateAuthenticatedUser(httpContext);
@@ -312,6 +312,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
             finally
             {
                 Aikido.Zen.DotNetFramework.Zen.SetUserAction = originalSetUserAction;
+                Aikido.Zen.DotNetFramework.Zen.ClearCurrentContext();
                 Agent.Instance.ClearContext();
             }
         }
@@ -327,7 +328,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
                     new HttpRequest(string.Empty, "http://test.local/api/test", string.Empty),
                     new HttpResponse(new StringWriter()));
                 var aikidoContext = new Context();
-                httpContext.Items["Aikido.Zen.Context"] = aikidoContext;
+                Aikido.Zen.DotNetFramework.Zen.SetCurrentContext(aikidoContext);
                 Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction = _ => "configured-group";
 
                 ContextModule.PopulateRateLimitGroup(httpContext);
@@ -337,6 +338,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
             finally
             {
                 Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction = originalSetRateLimitGroupAction;
+                Aikido.Zen.DotNetFramework.Zen.ClearCurrentContext();
             }
         }
 
@@ -350,6 +352,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
                 var httpContext = new HttpContext(
                     new HttpRequest(string.Empty, "http://test.local/api/test", string.Empty),
                     new HttpResponse(new StringWriter()));
+                Aikido.Zen.DotNetFramework.Zen.ClearCurrentContext();
                 Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction = _ => "configured-group";
 
                 Assert.DoesNotThrow(() => ContextModule.PopulateRateLimitGroup(httpContext));
@@ -357,6 +360,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
             finally
             {
                 Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction = originalSetRateLimitGroupAction;
+                Aikido.Zen.DotNetFramework.Zen.ClearCurrentContext();
             }
         }
 
@@ -371,7 +375,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
                     new HttpRequest(string.Empty, "http://test.local/api/test", string.Empty),
                     new HttpResponse(new StringWriter()));
                 var aikidoContext = new Context { RateLimitGroup = "existing-group" };
-                httpContext.Items["Aikido.Zen.Context"] = aikidoContext;
+                Aikido.Zen.DotNetFramework.Zen.SetCurrentContext(aikidoContext);
                 Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction = _ => string.Empty;
 
                 ContextModule.PopulateRateLimitGroup(httpContext);
@@ -381,6 +385,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
             finally
             {
                 Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction = originalSetRateLimitGroupAction;
+                Aikido.Zen.DotNetFramework.Zen.ClearCurrentContext();
             }
         }
 

--- a/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
+++ b/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
@@ -280,6 +280,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
         {
             Agent.Instance.ClearContext();
             var originalSetUserAction = Aikido.Zen.DotNetFramework.Zen.SetUserAction;
+            var originalCurrent = HttpContext.Current;
 
             try
             {
@@ -295,6 +296,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
                     Route = "/api/test",
                     RemoteAddress = "127.0.0.1"
                 };
+                HttpContext.Current = httpContext;
                 Aikido.Zen.DotNetFramework.Zen.SetCurrentContext(aikidoContext);
                 Aikido.Zen.DotNetFramework.Zen.SetUserAction = _ => user;
 
@@ -313,6 +315,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
             {
                 Aikido.Zen.DotNetFramework.Zen.SetUserAction = originalSetUserAction;
                 Aikido.Zen.DotNetFramework.Zen.ClearCurrentContext();
+                HttpContext.Current = originalCurrent;
                 Agent.Instance.ClearContext();
             }
         }
@@ -321,6 +324,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
         public void PopulateRateLimitGroup_UpdatesExistingContextGroup()
         {
             var originalSetRateLimitGroupAction = Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction;
+            var originalCurrent = HttpContext.Current;
 
             try
             {
@@ -328,6 +332,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
                     new HttpRequest(string.Empty, "http://test.local/api/test", string.Empty),
                     new HttpResponse(new StringWriter()));
                 var aikidoContext = new Context();
+                HttpContext.Current = httpContext;
                 Aikido.Zen.DotNetFramework.Zen.SetCurrentContext(aikidoContext);
                 Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction = _ => "configured-group";
 
@@ -339,6 +344,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
             {
                 Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction = originalSetRateLimitGroupAction;
                 Aikido.Zen.DotNetFramework.Zen.ClearCurrentContext();
+                HttpContext.Current = originalCurrent;
             }
         }
 
@@ -346,12 +352,14 @@ namespace Aikido.Zen.Tests.DotNetFramework
         public void PopulateRateLimitGroup_DoesNothingWithoutContext()
         {
             var originalSetRateLimitGroupAction = Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction;
+            var originalCurrent = HttpContext.Current;
 
             try
             {
                 var httpContext = new HttpContext(
                     new HttpRequest(string.Empty, "http://test.local/api/test", string.Empty),
                     new HttpResponse(new StringWriter()));
+                HttpContext.Current = httpContext;
                 Aikido.Zen.DotNetFramework.Zen.ClearCurrentContext();
                 Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction = _ => "configured-group";
 
@@ -361,6 +369,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
             {
                 Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction = originalSetRateLimitGroupAction;
                 Aikido.Zen.DotNetFramework.Zen.ClearCurrentContext();
+                HttpContext.Current = originalCurrent;
             }
         }
 
@@ -368,6 +377,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
         public void PopulateRateLimitGroup_DoesNotOverwriteContextGroupWhenConfiguredGroupIsEmpty()
         {
             var originalSetRateLimitGroupAction = Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction;
+            var originalCurrent = HttpContext.Current;
 
             try
             {
@@ -375,6 +385,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
                     new HttpRequest(string.Empty, "http://test.local/api/test", string.Empty),
                     new HttpResponse(new StringWriter()));
                 var aikidoContext = new Context { RateLimitGroup = "existing-group" };
+                HttpContext.Current = httpContext;
                 Aikido.Zen.DotNetFramework.Zen.SetCurrentContext(aikidoContext);
                 Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction = _ => string.Empty;
 
@@ -386,6 +397,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
             {
                 Aikido.Zen.DotNetFramework.Zen.SetRateLimitGroupAction = originalSetRateLimitGroupAction;
                 Aikido.Zen.DotNetFramework.Zen.ClearCurrentContext();
+                HttpContext.Current = originalCurrent;
             }
         }
 

--- a/sample-apps/DotNetFramework.Sample.App/Controllers/ContentTypeController.cs
+++ b/sample-apps/DotNetFramework.Sample.App/Controllers/ContentTypeController.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Formatting;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Http;
+using Aikido.Zen.DotNetFramework;
 
 namespace DotNetFramework.Sample.App.Controllers
 {
@@ -20,7 +21,7 @@ namespace DotNetFramework.Sample.App.Controllers
         public IHttpActionResult PostFormUrlEncoded()
         {
             var form = HttpContext.Current.Request.Form;
-            return Ok(HttpContext.Current.Items["Aikido.Zen.Context"]);
+            return Ok(Zen.GetContext());
         }
 
         /// <summary>
@@ -31,7 +32,7 @@ namespace DotNetFramework.Sample.App.Controllers
         [Route("multipart")]
         public IHttpActionResult PostMultipartFormData()
         {
-            return Ok(HttpContext.Current.Items["Aikido.Zen.Context"]);
+            return Ok(Zen.GetContext());
         }
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace DotNetFramework.Sample.App.Controllers
         [Route("text")]
         public IHttpActionResult PostText()
         {
-            return Ok(HttpContext.Current.Items["Aikido.Zen.Context"]);
+            return Ok(Zen.GetContext());
         }
 
         /// <summary>
@@ -53,7 +54,7 @@ namespace DotNetFramework.Sample.App.Controllers
         [Route("json")]
         public IHttpActionResult PostJson()
         {
-            return Ok(HttpContext.Current.Items["Aikido.Zen.Context"]);
+            return Ok(Zen.GetContext());
         }
 
         /// <summary>
@@ -66,7 +67,7 @@ namespace DotNetFramework.Sample.App.Controllers
         {
             // we consume xml, but want to return json
             HttpContext.Current.Response.ContentType = "application/json";
-            return Json(HttpContext.Current.Items["Aikido.Zen.Context"]);
+            return Json(Zen.GetContext());
         }
     }
 }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Tracked outbound request state using ConditionalWeakTable and request association.
* Propagated detected outbound exceptions to request state and aborted requests.
* Added Inspector overload to accept context override and preserve AsyncLocal guard.

**🔧 Refactors**
* Moved .NET Framework request context to Zen.GetContext and helper methods.
* Changed request body reading to Task.Run wrapper to avoid ASP.NET deadlock.
* Updated sample controller to return context via Zen.GetContext instead of items.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/139312094?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->