### PR TITLE
Include inner exceptions when reporting issues

### DIFF
--- a/Aikido.Zen.Core/Api/Reporting.cs
+++ b/Aikido.Zen.Core/Api/Reporting.cs
@@ -30,12 +30,12 @@ namespace Aikido.Zen.Core.Api
             }
             catch (TaskCanceledException ex)
             {
-                LogHelper.WarningLog(Agent.Logger, $"Failed to report event (possible timeout): {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, ex, "Failed to report event (possible timeout)");
                 return new ReportingAPIResponse { Success = false, Error = "timeout" };
             }
             catch (Exception ex)
             {
-                LogHelper.WarningLog(Agent.Logger, $"Failed to report event: {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, ex, "Failed to report event");
                 return new ReportingAPIResponse { Success = false, Error = "unknown_error" };
             }
         }

--- a/Aikido.Zen.Core/Api/Reporting.cs
+++ b/Aikido.Zen.Core/Api/Reporting.cs
@@ -50,12 +50,12 @@ namespace Aikido.Zen.Core.Api
             }
             catch (TaskCanceledException ex)
             {
-                LogHelper.DebugLog(Agent.Logger, $"Retrieving Firewall Lists timed out; will retry on a future config update: {ex.Message}");
+                LogHelper.DebugLog(Agent.Logger, ex, "Retrieving Firewall Lists timed out; will retry on a future config update");
                 return new FirewallListsAPIResponse { Success = false, Error = "timeout" };
             }
             catch (Exception ex)
             {
-                LogHelper.WarningLog(Agent.Logger, $"Failed to retrieve Firewall Lists: {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, ex, "Failed to retrieve Firewall Lists");
                 return new FirewallListsAPIResponse { Success = false, Error = "unknown_error" };
             }
         }

--- a/Aikido.Zen.Core/Api/Runtime.cs
+++ b/Aikido.Zen.Core/Api/Runtime.cs
@@ -25,12 +25,12 @@ namespace Aikido.Zen.Core.Api
             }
             catch (TaskCanceledException ex)
             {
-                LogHelper.WarningLog(Agent.Logger, $"Failed to retrieve config last updated (possible timeout): {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, ex, "Failed to retrieve config last updated (possible timeout)");
                 return new ConfigLastUpdatedAPIResponse { Success = false, Error = "timeout" };
             }
             catch (Exception ex)
             {
-                LogHelper.WarningLog(Agent.Logger, $"Failed to retrieve config last updated: {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, ex, "Failed to retrieve config last updated");
                 return new ConfigLastUpdatedAPIResponse { Success = false, Error = "unknown_error" };
             }
         }
@@ -45,12 +45,12 @@ namespace Aikido.Zen.Core.Api
             }
             catch (TaskCanceledException ex)
             {
-                LogHelper.WarningLog(Agent.Logger, $"Failed to retrieve config (possible timeout): {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, ex, "Failed to retrieve config (possible timeout)");
                 return new ReportingAPIResponse { Success = false, Error = "timeout" };
             }
             catch (Exception ex)
             {
-                LogHelper.WarningLog(Agent.Logger, $"Failed to retrieve config: {ex.Message}");
+                LogHelper.WarningLog(Agent.Logger, ex, "Failed to retrieve config");
                 return new ReportingAPIResponse { Success = false, Error = "unknown_error" };
             }
         }

--- a/Aikido.Zen.Core/DefaultLogger.cs
+++ b/Aikido.Zen.Core/DefaultLogger.cs
@@ -15,6 +15,10 @@ namespace Aikido.Zen.Core
             {
                 message = formatter(state, exception);
             }
+            if (exception != null)
+            {
+                message = $"{message}{Environment.NewLine}{exception}";
+            }
             // log to console, by default it works for .Net core web apps
             Console.WriteLine(message);
             // log to debug, by default it works for .Net framework web apps

--- a/Aikido.Zen.Core/DefaultLogger.cs
+++ b/Aikido.Zen.Core/DefaultLogger.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using Aikido.Zen.Core.Helpers;
 using Microsoft.Extensions.Logging;
 
 namespace Aikido.Zen.Core
@@ -17,7 +18,7 @@ namespace Aikido.Zen.Core
             }
             if (exception != null)
             {
-                message = $"{message}{Environment.NewLine}{exception}";
+                message = LogHelper.SanitizeMessage($"{message}: {exception}");
             }
             // log to console, by default it works for .Net core web apps
             Console.WriteLine(message);

--- a/Aikido.Zen.Core/DefaultLogger.cs
+++ b/Aikido.Zen.Core/DefaultLogger.cs
@@ -18,7 +18,7 @@ namespace Aikido.Zen.Core
             }
             if (exception != null)
             {
-                message = LogHelper.SanitizeMessage($"{message}: {exception}");
+                message = LogHelper.SanitizeMessage(message, exception);
             }
             // log to console, by default it works for .Net core web apps
             Console.WriteLine(message);

--- a/Aikido.Zen.Core/Helpers/LogHelper.cs
+++ b/Aikido.Zen.Core/Helpers/LogHelper.cs
@@ -36,6 +36,16 @@ namespace Aikido.Zen.Core.Helpers
             }
         }
 
+        private static string SanitizeMessage(string message, Exception exception)
+        {
+            if (exception == null)
+            {
+                return SanitizeMessage(message);
+            }
+
+            return SanitizeMessage($"{message}: {exception}");
+        }
+
         /// <summary>
         /// Logs a debug message if debugging is enabled, after sanitizing the message and applying rate limiting.
         /// </summary>
@@ -54,17 +64,9 @@ namespace Aikido.Zen.Core.Helpers
             if (EnvironmentHelper.IsDebugging)
             {
                 // Sanitize the message to prevent log injection
-                string sanitizedMessage = SanitizeMessage(message);
-                if (exception == null)
-                {
-                    // we log the message to the outputs defined by the application
-                    logger.LogDebug(sanitizedMessage);
-                }
-                else
-                {
-                    // we log the message to the outputs defined by the application
-                    logger.LogDebug(exception, sanitizedMessage);
-                }
+                string sanitizedMessage = SanitizeMessage(message, exception);
+                // we log the message to the outputs defined by the application
+                logger.LogDebug(sanitizedMessage);
                 // we also log the message to the debug output in case the application is running in a debugger
                 Debug.WriteLine(sanitizedMessage);
             }
@@ -86,18 +88,9 @@ namespace Aikido.Zen.Core.Helpers
         public static void ErrorLog(ILogger logger, Exception exception, string message)
         {
             // Sanitize the message to prevent log injection
-            string sanitizedMessage = SanitizeMessage(message);
-
-            if (exception == null)
-            {
-                // we log the message to the outputs defined by the application
-                logger.LogError(sanitizedMessage);
-            }
-            else
-            {
-                // we log the message to the outputs defined by the application
-                logger.LogError(exception, sanitizedMessage);
-            }
+            string sanitizedMessage = SanitizeMessage(message, exception);
+            // we log the message to the outputs defined by the application
+            logger.LogError(sanitizedMessage);
         }
 
         /// <summary>
@@ -116,18 +109,9 @@ namespace Aikido.Zen.Core.Helpers
         public static void WarningLog(ILogger logger, Exception exception, string message)
         {
             // Sanitize the message to prevent log injection
-            string sanitizedMessage = SanitizeMessage(message);
-
-            if (exception == null)
-            {
-                // we log the message to the outputs defined by the application
-                logger.LogWarning(sanitizedMessage);
-            }
-            else
-            {
-                // we log the message to the outputs defined by the application
-                logger.LogWarning(exception, sanitizedMessage);
-            }
+            string sanitizedMessage = SanitizeMessage(message, exception);
+            // we log the message to the outputs defined by the application
+            logger.LogWarning(sanitizedMessage);
         }
 
         /// <summary>

--- a/Aikido.Zen.Core/Helpers/LogHelper.cs
+++ b/Aikido.Zen.Core/Helpers/LogHelper.cs
@@ -36,14 +36,25 @@ namespace Aikido.Zen.Core.Helpers
             }
         }
 
-        private static string SanitizeMessage(string message, Exception exception)
+        internal static string SanitizeMessage(string message, Exception exception)
         {
             if (exception == null)
             {
                 return SanitizeMessage(message);
             }
 
-            return SanitizeMessage($"{message}: {exception}");
+            return SanitizeMessage($"{message}: {SummarizeException(exception)}");
+        }
+
+        private static string SummarizeException(Exception exception)
+        {
+            var summaries = new List<string>();
+            for (var current = exception; current != null; current = current.InnerException)
+            {
+                summaries.Add($"{current.GetType().Name}: {current.Message}");
+            }
+
+            return string.Join(" Inner: ", summaries);
         }
 
         /// <summary>

--- a/Aikido.Zen.Core/Helpers/LogHelper.cs
+++ b/Aikido.Zen.Core/Helpers/LogHelper.cs
@@ -41,14 +41,30 @@ namespace Aikido.Zen.Core.Helpers
         /// </summary>
         /// <param name="logger">The logger instance to use.</param>
         /// <param name="message">The message to log.</param>
-        public static void DebugLog(ILogger logger, string message)
+        public static void DebugLog(ILogger logger, string message) => DebugLog(logger, null, message);
+
+        /// <summary>
+        /// Logs a debug message with an exception if debugging is enabled, after sanitizing the message.
+        /// </summary>
+        /// <param name="logger">The logger instance to use.</param>
+        /// <param name="exception">The exception associated with the debug message, if any.</param>
+        /// <param name="message">The message to log.</param>
+        public static void DebugLog(ILogger logger, Exception exception, string message)
         {
             if (EnvironmentHelper.IsDebugging)
             {
                 // Sanitize the message to prevent log injection
                 string sanitizedMessage = SanitizeMessage(message);
-                // we log the message to the outputs defined by the application
-                logger.LogDebug(sanitizedMessage);
+                if (exception == null)
+                {
+                    // we log the message to the outputs defined by the application
+                    logger.LogDebug(sanitizedMessage);
+                }
+                else
+                {
+                    // we log the message to the outputs defined by the application
+                    logger.LogDebug(exception, sanitizedMessage);
+                }
                 // we also log the message to the debug output in case the application is running in a debugger
                 Debug.WriteLine(sanitizedMessage);
             }

--- a/Aikido.Zen.Test/Helpers/LogHelperTests.cs
+++ b/Aikido.Zen.Test/Helpers/LogHelperTests.cs
@@ -137,7 +137,17 @@ namespace Aikido.Zen.Test.Helpers
         public void WarningLog_WithException_ShouldLogExceptionAsWarning()
         {
             var message = "Test warning with exception";
-            var exception = new InvalidOperationException("test\nexception");
+            Exception exception;
+            try
+            {
+                throw new InvalidOperationException(
+                    "test\nexception",
+                    new TimeoutException("inner\ttimeout"));
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
 
             LogHelper.WarningLog(_loggerMock.Object, exception, message);
 
@@ -146,7 +156,9 @@ namespace Aikido.Zen.Test.Helpers
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) =>
                     v.ToString()!.Contains(message) &&
-                    v.ToString()!.Contains("System.InvalidOperationException: testexception")),
+                    v.ToString()!.Contains("InvalidOperationException: testexception") &&
+                    v.ToString()!.Contains("Inner: TimeoutException: innertimeout") &&
+                    !v.ToString()!.Contains(nameof(WarningLog_WithException_ShouldLogExceptionAsWarning))),
                 It.Is<Exception?>(e => e == null),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
         }

--- a/Aikido.Zen.Test/Helpers/LogHelperTests.cs
+++ b/Aikido.Zen.Test/Helpers/LogHelperTests.cs
@@ -137,15 +137,17 @@ namespace Aikido.Zen.Test.Helpers
         public void WarningLog_WithException_ShouldLogExceptionAsWarning()
         {
             var message = "Test warning with exception";
-            var exception = new InvalidOperationException("test exception");
+            var exception = new InvalidOperationException("test\nexception");
 
             LogHelper.WarningLog(_loggerMock.Object, exception, message);
 
             _loggerMock.Verify(logger => logger.Log(
                 It.Is<LogLevel>(level => level == LogLevel.Warning),
                 It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.EndsWith(message)),
-                exception,
+                It.Is<It.IsAnyType>((v, t) =>
+                    v.ToString()!.Contains(message) &&
+                    v.ToString()!.Contains("System.InvalidOperationException: testexception")),
+                It.Is<Exception?>(e => e == null),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
         }
 

--- a/Aikido.Zen.Test/Helpers/LogHelperTests.cs
+++ b/Aikido.Zen.Test/Helpers/LogHelperTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Aikido.Zen.Core;
 using Aikido.Zen.Core.Helpers;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -161,6 +162,38 @@ namespace Aikido.Zen.Test.Helpers
                     !v.ToString()!.Contains(nameof(WarningLog_WithException_ShouldLogExceptionAsWarning))),
                 It.Is<Exception?>(e => e == null),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+        }
+
+        [Test]
+        public void DefaultLogger_WithException_ShouldUseSanitizedExceptionSummary()
+        {
+            var originalOut = Console.Out;
+            var originalLogger = Agent.Logger;
+            var output = new StringWriter();
+            try
+            {
+                Console.SetOut(output);
+                Agent.ConfigureLogger(null);
+                var exception = new InvalidOperationException(
+                    "outer\nmessage",
+                    new TimeoutException("inner\ttimeout"));
+                Exception? noException = null;
+                Func<string, Exception?, string> formatter = (state, _) => state;
+
+                Agent.Logger.Log(LogLevel.Warning, new EventId(), "Plain message", noException, formatter);
+                Agent.Logger.Log(LogLevel.Warning, new EventId(), "Failed\rmessage", exception, formatter);
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Agent.ConfigureLogger(originalLogger);
+            }
+
+            var logged = output.ToString();
+
+            Assert.That(logged, Does.Contain("Plain message"));
+            Assert.That(logged, Does.Contain("AIKIDO: Failedmessage: InvalidOperationException: outermessage Inner: TimeoutException: innertimeout"));
+            Assert.That(logged, Does.Not.Contain(nameof(DefaultLogger_WithException_ShouldUseSanitizedExceptionSummary)));
         }
 
         [Test]


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 3 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Logged full exception objects instead of only exception messages across APIs
* Introduced LogHelper methods to sanitize and summarize exception details
* Updated DefaultLogger to include sanitized exception summaries in output


<sup>[More info](https://app.aikido.dev/featurebranch/scan/147148963?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->