### PR TITLE
Fix user capture across middleware pipelines

### DIFF
--- a/Aikido.Zen.Core/Agent.cs
+++ b/Aikido.Zen.Core/Agent.cs
@@ -295,18 +295,6 @@ namespace Aikido.Zen.Core
         }
 
         /// <summary>
-        /// Captures the current user
-        /// </summary>
-        /// <param name="context">The current context</param>
-        public void CaptureRequestUser(Context context)
-        {
-            if (context.User != null)
-                _context.AddUser(context.User, context.RemoteAddress);
-            if (context.User != null)
-                LogHelper.DebugLog(Logger, $"Capturing inbound request from user: {context.User.Id}");
-        }
-
-        /// <summary>
         /// Increments the total request count
         /// </summary>
         public void IncrementTotalRequestCount()
@@ -335,13 +323,16 @@ namespace Aikido.Zen.Core
         }
 
         /// <summary>
-        /// Captures the current user
+        /// Captures the current user.
         /// </summary>
-        /// <param name="user"></param>
-        /// <param name="ipAddress"></param>
-        public void CaptureUser(User user, string ipAddress)
+        /// <param name="user">The current user.</param>
+        /// <param name="remoteAddress">The user's remote address.</param>
+        internal void CaptureUser(User user, string remoteAddress)
         {
-            _context.AddUser(user, ipAddress);
+            if (user == null)
+                return;
+
+            _context.AddUser(user, remoteAddress);
         }
 
         /// <summary>

--- a/Aikido.Zen.Core/Context.cs
+++ b/Aikido.Zen.Core/Context.cs
@@ -32,8 +32,6 @@ namespace Aikido.Zen.Core
         public object ParsedBody { get; set; }
 
         internal bool Bypassed { get; set; }
-        internal bool ContextMiddlewareInstalled { get; set; }
-        internal bool BlockingMiddlewareInstalled { get; set; }
 
         public bool ConsumedRateLimitForIP { get; set; }
         public bool ConsumedRateLimitForUser { get; set; }

--- a/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/BlockingMiddleware.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 using System.Web; // Import for HTML encoding
 using Aikido.Zen.Core;
 using Aikido.Zen.Core.Helpers;
@@ -28,12 +26,6 @@ namespace Aikido.Zen.DotNetCore.Middleware
                     // call the next middleware
                     await next(context);
                     return;
-                }
-
-                var user = context.Items["Aikido.Zen.CurrentUser"] as User;
-                if (user != null)
-                {
-                    Agent.Instance.Context.AddUser(user, ipAddress: aikidoContext.RemoteAddress);
                 }
 
                 // block the request if the user is blocked

--- a/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
+++ b/Aikido.Zen.DotNetCore/Middleware/ContextMiddleware.cs
@@ -90,9 +90,7 @@ namespace Aikido.Zen.DotNetCore.Middleware
                 context.ParsedUserInput = httpData.FlattenedData;
                 context.Body = request.Body;
                 context.ParsedBody = httpData.ParsedBody;
-                // Add user information to the agent
-                // every x minutes, this information will be sent to the Zen server as a heartbeat event, and the collected info will be cleared
-                Agent.Instance.CaptureRequestUser(context);
+
                 httpContext.Items["Aikido.Zen.Context"] = context;
             }
             catch (Exception e)
@@ -106,6 +104,8 @@ namespace Aikido.Zen.DotNetCore.Middleware
             }
             finally
             {
+                // Capture the final user once, including users set after the Zen middleware.
+                Agent.Instance.CaptureUser(context.User, context.RemoteAddress);
                 HandleCompletedRequest(context, httpContext.Response.StatusCode);
             }
         }

--- a/Aikido.Zen.DotNetCore/Zen.cs
+++ b/Aikido.Zen.DotNetCore/Zen.cs
@@ -85,11 +85,6 @@ namespace Aikido.Zen.DotNetCore
                     "Zen.SetUser(...) was called after the Zen middleware. Register the SetUser middleware before UseZenFirewall() so user blocking, and rate limiting work correctly.");
             }
 
-            if (Context.IsBypassed(aikidoContext))
-            {
-                return;
-            }
-
             // Preserve late users for end-of-request reporting.
             // Blocking and rate limiting have already run.
             aikidoContext.User = user;

--- a/Aikido.Zen.DotNetCore/Zen.cs
+++ b/Aikido.Zen.DotNetCore/Zen.cs
@@ -82,7 +82,7 @@ namespace Aikido.Zen.DotNetCore
             {
                 LogHelper.WarningLog(
                     Agent.Logger,
-                    "Zen.SetUser(...) was called after the Zen middleware. Register the SetUser middleware before UseZenFirewall() so user reporting, blocking, and rate limiting work correctly.");
+                    "Zen.SetUser(...) was called after the Zen middleware. Register the SetUser middleware before UseZenFirewall() so user blocking, and rate limiting work correctly.");
             }
 
             if (Context.IsBypassed(aikidoContext))

--- a/Aikido.Zen.DotNetCore/Zen.cs
+++ b/Aikido.Zen.DotNetCore/Zen.cs
@@ -17,6 +17,7 @@ namespace Aikido.Zen.DotNetCore
     {
         private static IServiceProvider _serviceProvider;
         private static IHttpContextAccessor _httpContextAccessor;
+        private static int _lateSetUserWarningLogged;
 
         public static void Initialize(IServiceProvider serviceProvider, IHttpContextAccessor httpContextAccessor)
         {
@@ -68,7 +69,30 @@ namespace Aikido.Zen.DotNetCore
         public static void SetUser(string id, string name, HttpContext context)
         {
             var user = new User(id, name);
-            context.Items["Aikido.Zen.CurrentUser"] = user;
+
+            var aikidoContext = context.Items["Aikido.Zen.Context"] as Context;
+            if (aikidoContext == null)
+            {
+                // Correct order: ContextMiddleware captures the stored user.
+                context.Items["Aikido.Zen.CurrentUser"] = user;
+                return;
+            }
+
+            if (Interlocked.Exchange(ref _lateSetUserWarningLogged, 1) == 0)
+            {
+                LogHelper.WarningLog(
+                    Agent.Logger,
+                    "Zen.SetUser(...) was called after the Zen middleware. Register the SetUser middleware before UseZenFirewall() so user reporting, blocking, and rate limiting work correctly.");
+            }
+
+            if (Context.IsBypassed(aikidoContext))
+            {
+                return;
+            }
+
+            // Preserve late users for end-of-request reporting.
+            // Blocking and rate limiting have already run.
+            aikidoContext.User = user;
         }
 
         public static void SetRateLimitGroup(string id, HttpContext context)

--- a/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/BlockingModule.cs
@@ -45,12 +45,6 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                     return;
                 }
 
-                var user = aikidoContext.User;
-                if (user != null)
-                {
-                    Agent.Instance.Context.AddUser(user, aikidoContext.RemoteAddress);
-                }
-
                 // block the request if the user is blocked
                 if (Agent.Instance.Context.IsBlocked(aikidoContext, out var reason))
                 {

--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -144,7 +144,6 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
             context.ParsedUserInput = httpData.FlattenedData;
             context.Body = request.InputStream;
             context.ParsedBody = httpData.ParsedBody;
-            Agent.Instance.CaptureRequestUser(context);
         }
 
         private void Context_EndRequest(object sender, EventArgs e)

--- a/Aikido.Zen.Test.End2End/AikidoBlockingTests.cs
+++ b/Aikido.Zen.Test.End2End/AikidoBlockingTests.cs
@@ -1,10 +1,16 @@
 using System.Net;
 using System.Net.Http.Json;
+using Aikido.Zen.Core;
 using Aikido.Zen.DotNetCore;
 using Aikido.Zen.Server.Mock.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using SQLiteSampleApp;
+using ZenApi = Aikido.Zen.DotNetCore.Zen;
 
 namespace Aikido.Zen.Test.End2End
 {
@@ -21,25 +27,36 @@ namespace Aikido.Zen.Test.End2End
 
         private WebApplicationFactory<SQLiteStartup> CreateSampleAppFactory()
         {
-            var factory = new WebApplicationFactory<SQLiteStartup>()
+            return new WebApplicationFactory<SQLiteStartup>()
+                .WithWebHostBuilder(ConfigureSampleApp);
+        }
+
+        private WebApplicationFactory<SQLiteStartup> CreateLateSetUserSampleAppFactory()
+        {
+            return new WebApplicationFactory<SQLiteStartup>()
                 .WithWebHostBuilder(builder =>
                 {
-                    builder.ConfigureServices(services =>
-                    {
-                        services.AddZenFirewall(options =>
-                        {
-                            options.UseHttpClient(MockServerClient);
-                        });
-                    });
-                    builder.ConfigureAppConfiguration((context, config) =>
-                    {
-                        foreach (var envVar in SampleAppEnvironmentVariables)
-                        {
-                            Environment.SetEnvironmentVariable(envVar.Key, envVar.Value);
-                        }
-                    });
+                    builder.UseStartup<LateSetUserStartup>();
+                    ConfigureSampleApp(builder);
                 });
-            return factory;
+        }
+
+        private void ConfigureSampleApp(IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.AddZenFirewall(options =>
+                {
+                    options.UseHttpClient(MockServerClient);
+                });
+            });
+            builder.ConfigureAppConfiguration((_, _) =>
+            {
+                foreach (var envVar in SampleAppEnvironmentVariables)
+                {
+                    Environment.SetEnvironmentVariable(envVar.Key, envVar.Value);
+                }
+            });
         }
 
         [OneTimeSetUp]
@@ -72,6 +89,47 @@ namespace Aikido.Zen.Test.End2End
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
             var responseBody = await response.Content.ReadAsStringAsync();
             Assert.That(responseBody, Does.Contain("Your request is blocked: User is blocked"));
+        }
+
+        [Test, NonParallelizable]
+        public async Task WhenBlockedUserIsSetAfterZenMiddleware_ShouldNotBlockAndShouldCaptureUserOnce()
+        {
+            const string userId = "late-user";
+            const string remoteAddress = "203.0.113.7";
+
+            Agent.Instance.Context.Config.Clear();
+            Agent.Instance.ClearContext();
+            await SetMode(false, true);
+            await MockServerClient.PostAsJsonAsync("/api/runtime/config", new Dictionary<string, object>
+            {
+                ["blockedUserIds"] = new[] { userId },
+            });
+
+            SampleAppClient = CreateLateSetUserSampleAppFactory().CreateClient();
+
+            for (var attempt = 0; attempt < 50 && !Agent.Instance.Context.Config.IsUserBlocked(userId); attempt++)
+            {
+                await Task.Delay(100);
+            }
+
+            Assert.That(
+                Agent.Instance.Context.Config.IsUserBlocked(userId),
+                Is.True,
+                "The test must load the blocked-user configuration before sending the request.");
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/late-user");
+            request.Headers.Add("user", userId);
+            using var response = await SampleAppClient.SendAsync(request);
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+            var capturedUser = Agent.Instance.Context.Users.SingleOrDefault(user => user.Id == userId);
+            Assert.Multiple(() =>
+            {
+                Assert.That(capturedUser, Is.Not.Null);
+                Assert.That(capturedUser?.Hits, Is.EqualTo(1));
+                Assert.That(capturedUser?.LastIpAddress, Is.EqualTo(remoteAddress));
+            });
         }
 
         [Test]
@@ -717,6 +775,43 @@ namespace Aikido.Zen.Test.End2End
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
             var responseBody = await response.Content.ReadAsStringAsync();
             Assert.That(responseBody, Does.Contain("Request blocked due to security policy."));
+        }
+    }
+
+    public class LateSetUserStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddZenFirewall();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.Use((context, next) =>
+            {
+                context.Connection.RemoteIpAddress = IPAddress.Parse("203.0.113.7");
+                return next();
+            });
+
+            app.UseRouting();
+            app.UseZenFirewall();
+
+            // Deliberately incorrect order for late SetUser E2E coverage.
+            app.Use((context, next) =>
+            {
+                var userId = context.Request.Headers["user"].ToString();
+                if (!string.IsNullOrEmpty(userId))
+                {
+                    ZenApi.SetUser(userId, userId, context);
+                }
+
+                return next();
+            });
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapGet("/late-user", () => Results.Ok());
+            });
         }
     }
 }

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -40,7 +40,7 @@ namespace Aikido.Zen.Test
                 Method = "GET",
                 RemoteAddress = "127.0.0.1"
             };
-            _agent.CaptureRequestUser(context);
+            _agent.CaptureUser(context.User, context.RemoteAddress);
             _agent.IncrementTotalRequestCount();
             _agent.CaptureOutboundRequest("test.com", 443);
             var startedTime = _agent.Context.Started;
@@ -567,7 +567,7 @@ namespace Aikido.Zen.Test
             };
 
             // Act
-            _agent.CaptureRequestUser(context);
+            _agent.CaptureUser(context.User, context.RemoteAddress);
             _agent.IncrementTotalRequestCount();
 
             // Assert
@@ -590,7 +590,7 @@ namespace Aikido.Zen.Test
             };
 
             // Act
-            _agent.CaptureRequestUser(context);
+            _agent.CaptureUser(context.User, context.RemoteAddress);
             _agent.IncrementTotalRequestCount();
 
             // Assert

--- a/Aikido.Zen.Test/ContextTests.cs
+++ b/Aikido.Zen.Test/ContextTests.cs
@@ -41,8 +41,6 @@ namespace Aikido.Zen.Test
             Assert.That(_context.UserAgent, Is.EqualTo(string.Empty));
             Assert.That(_context.IsGraphQL, Is.False);
             Assert.That(_context.ParsedBody, Is.Null);
-            Assert.That(_context.ContextMiddlewareInstalled, Is.False);
-            Assert.That(_context.BlockingMiddlewareInstalled, Is.False);
             Assert.That(_context.ConsumedRateLimitForIP, Is.False);
             Assert.That(_context.ConsumedRateLimitForUser, Is.False);
         }

--- a/Aikido.Zen.Tests.DotNetCore/BlockingMiddlewareTests.cs
+++ b/Aikido.Zen.Tests.DotNetCore/BlockingMiddlewareTests.cs
@@ -1,64 +1,91 @@
-using System.Linq;
 using System.Net;
-using System.Threading.Tasks;
 using Aikido.Zen.Core;
 using Aikido.Zen.Core.Helpers;
 using Aikido.Zen.Core.Models;
 using Aikido.Zen.DotNetCore.Middleware;
 using Microsoft.AspNetCore.Http;
-using NUnit.Framework;
 
 namespace Aikido.Zen.Tests.DotNetCore
 {
     public class BlockingMiddlewareTests
     {
         /// <summary>
-        /// ContextMiddleware resolves the real client IP from configured proxy
-        /// headers (e.g. AIKIDO_CLIENT_IP_HEADER) and stores it on
-        /// Context.RemoteAddress. BlockingMiddleware must attribute the
-        /// authenticated user to that resolved value, not to
-        /// Connection.RemoteIpAddress which is just the previous TCP hop
-        /// (ingress/proxy pod) and therefore the same for every request.
+        /// ContextMiddleware stores the client IP resolved by ASP.NET proxy handling
+        /// on Context.RemoteAddress. The Zen middleware pipeline must attribute the
+        /// authenticated user to that resolved value.
         /// </summary>
         [Test]
         public async Task InvokeAsync_RecordsUser_WithResolvedClientIpFromContext()
         {
             // Arrange
-            const string connectionRemoteIp = "10.0.0.5";   // previous TCP hop (e.g. ingress pod)
-            const string resolvedClientIp = "203.0.113.7";  // real client, already resolved by ContextMiddleware
+            const string resolvedClientIp = "203.0.113.7";
             const string userId = "user42";
+            var user = new User(userId, "User Forty Two");
 
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Scheme = "http";
             httpContext.Request.Host = new HostString("test.local");
             httpContext.Request.Path = "/api/test";
             httpContext.Request.Method = "GET";
-            httpContext.Connection.RemoteIpAddress = IPAddress.Parse(connectionRemoteIp);
-            httpContext.Items["Aikido.Zen.Context"] = new Context
-            {
-                Method = "GET",
-                Route = "/api/test",
-                RemoteAddress = resolvedClientIp,
-            };
-            httpContext.Items["Aikido.Zen.CurrentUser"] = new User(userId, "User Forty Two");
+            httpContext.Connection.RemoteIpAddress = IPAddress.Parse(resolvedClientIp);
+            httpContext.Items["Aikido.Zen.CurrentUser"] = user;
 
             try
             {
                 Agent.Instance.Context.Config.Clear();
                 Agent.Instance.ClearContext();
 
-                var middleware = new BlockingMiddleware();
+                var contextMiddleware = new ContextMiddleware([]);
+                var blockingMiddleware = new BlockingMiddleware();
 
                 // Act
-                await middleware.InvokeAsync(httpContext, _ => Task.CompletedTask);
+                await contextMiddleware.InvokeAsync(
+                    httpContext,
+                    requestContext => blockingMiddleware.InvokeAsync(requestContext, _ => Task.CompletedTask));
 
                 // Assert
                 var recorded = Agent.Instance.Context.Users.SingleOrDefault(u => u.Id == userId);
                 Assert.Multiple(() =>
                 {
-                    Assert.That(recorded, Is.Not.Null, "User should have been recorded by BlockingMiddleware");
+                    Assert.That(recorded, Is.Not.Null, "User should have been recorded by the Zen middleware pipeline");
                     Assert.That(recorded?.LastIpAddress, Is.EqualTo(resolvedClientIp));
                 });
+            }
+            finally
+            {
+                Agent.Instance.ClearContext();
+                Agent.Instance.Context.Config.Clear();
+            }
+        }
+
+        [Test]
+        public async Task InvokeAsync_DoesNotCaptureUserAgain()
+        {
+            const string remoteAddress = "203.0.113.7";
+            const string userId = "user42";
+            var user = new User(userId, "User Forty Two");
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Scheme = "http";
+            httpContext.Request.Host = new HostString("test.local");
+            httpContext.Request.Path = "/api/test";
+            httpContext.Request.Method = "GET";
+            httpContext.Connection.RemoteIpAddress = IPAddress.Parse(remoteAddress);
+            httpContext.Items["Aikido.Zen.CurrentUser"] = user;
+
+            try
+            {
+                Agent.Instance.Context.Config.Clear();
+                Agent.Instance.ClearContext();
+
+                var contextMiddleware = new ContextMiddleware([]);
+                var blockingMiddleware = new BlockingMiddleware();
+
+                await contextMiddleware.InvokeAsync(
+                    httpContext,
+                    requestContext => blockingMiddleware.InvokeAsync(requestContext, _ => Task.CompletedTask));
+
+                var recorded = Agent.Instance.Context.Users.SingleOrDefault(u => u.Id == userId);
+                Assert.That(recorded?.Hits, Is.EqualTo(1), "BlockingMiddleware must not count the same request twice");
             }
             finally
             {

--- a/Aikido.Zen.Tests.DotNetCore/ZenTests.cs
+++ b/Aikido.Zen.Tests.DotNetCore/ZenTests.cs
@@ -1,16 +1,110 @@
+using System.Net;
+using Aikido.Zen.Core;
+using Aikido.Zen.Core.Models;
+using Aikido.Zen.DotNetCore.Middleware;
 using Microsoft.AspNetCore.Http;
-using NUnit.Framework;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ZenApi = Aikido.Zen.DotNetCore.Zen;
 
 namespace Aikido.Zen.Tests.DotNetCore
 {
     public class ZenTests
     {
+        private Mock<ILogger> _loggerMock;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _loggerMock = new Mock<ILogger>();
+            Agent.ConfigureLogger(_loggerMock.Object);
+            Agent.Instance.Context.Config.Clear();
+            Agent.Instance.ClearContext();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Agent.Instance.ClearContext();
+            Agent.Instance.Context.Config.Clear();
+            Agent.ConfigureLogger(null);
+        }
+
+        [Test]
+        public void SetUser_BeforeContextMiddleware_StoresUserWithoutCapturing()
+        {
+            var httpContext = new DefaultHttpContext();
+
+            ZenApi.SetUser("user-123", "Test User", httpContext);
+
+            var currentUser = httpContext.Items["Aikido.Zen.CurrentUser"] as User;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(currentUser, Is.Not.Null);
+                Assert.That(currentUser?.Id, Is.EqualTo("user-123"));
+                Assert.That(Agent.Instance.Context.Users, Is.Empty);
+            });
+
+            _loggerMock.Verify(logger => logger.Log(
+                It.Is<LogLevel>(level => level == LogLevel.Warning),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Never);
+        }
+
+        [Test]
+        public async Task SetUser_AfterContextMiddleware_WarnsOnceAndCapturesFinalUser()
+        {
+            var bypassedHttpContext = new DefaultHttpContext();
+            var bypassedContext = new Context { Bypassed = true };
+            bypassedHttpContext.Items["Aikido.Zen.Context"] = bypassedContext;
+
+            ZenApi.SetUser("bypassed-user", "Bypassed User", bypassedHttpContext);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Scheme = "http";
+            httpContext.Request.Host = new HostString("test.local");
+            httpContext.Request.Path = "/api/test";
+            httpContext.Request.Method = "GET";
+            httpContext.Connection.RemoteIpAddress = IPAddress.Parse("203.0.113.7");
+            var contextMiddleware = new ContextMiddleware([]);
+
+            await contextMiddleware.InvokeAsync(httpContext, requestContext =>
+            {
+                ZenApi.SetUser("user-123", "First User", requestContext);
+                ZenApi.SetUser("user-456", "Second User", requestContext);
+                Assert.That(Agent.Instance.Context.Users, Is.Empty);
+                return Task.CompletedTask;
+            });
+
+            var aikidoContext = httpContext.Items["Aikido.Zen.Context"] as Context;
+            var capturedUser = Agent.Instance.Context.Users.SingleOrDefault(user => user.Id == "user-456");
+
+            _loggerMock.Verify(logger => logger.Log(
+                It.Is<LogLevel>(level => level == LogLevel.Warning),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((value, _) => value.ToString()!.Contains("before UseZenFirewall()")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(bypassedContext.User, Is.Null);
+                Assert.That(Agent.Instance.Context.Users.Any(user => user.Id == "bypassed-user"), Is.False);
+                Assert.That(aikidoContext?.User?.Id, Is.EqualTo("user-456"));
+                Assert.That(Agent.Instance.Context.Users.Any(user => user.Id == "user-123"), Is.False);
+                Assert.That(capturedUser?.Hits, Is.EqualTo(1));
+            });
+        }
+
         [Test]
         public void SetRateLimitGroup_SetsGroupOnHttpContext()
         {
             var context = new DefaultHttpContext();
 
-            Aikido.Zen.DotNetCore.Zen.SetRateLimitGroup("team-1", context);
+            ZenApi.SetRateLimitGroup("team-1", context);
 
             Assert.That(context.Items["Aikido.Zen.RateLimitGroup"], Is.EqualTo("team-1"));
         }
@@ -20,7 +114,7 @@ namespace Aikido.Zen.Tests.DotNetCore
         {
             var context = new DefaultHttpContext();
 
-            Aikido.Zen.DotNetCore.Zen.SetRateLimitGroup(string.Empty, context);
+            ZenApi.SetRateLimitGroup(string.Empty, context);
 
             Assert.That(context.Items.ContainsKey("Aikido.Zen.RateLimitGroup"), Is.False);
         }

--- a/Aikido.Zen.Tests.DotNetCore/ZenTests.cs
+++ b/Aikido.Zen.Tests.DotNetCore/ZenTests.cs
@@ -91,7 +91,7 @@ namespace Aikido.Zen.Tests.DotNetCore
 
             Assert.Multiple(() =>
             {
-                Assert.That(bypassedContext.User, Is.Null);
+                Assert.That(bypassedContext.User?.Id, Is.EqualTo("bypassed-user"));
                 Assert.That(Agent.Instance.Context.Users.Any(user => user.Id == "bypassed-user"), Is.False);
                 Assert.That(aikidoContext?.User?.Id, Is.EqualTo("user-456"));
                 Assert.That(Agent.Instance.Context.Users.Any(user => user.Id == "user-123"), Is.False);

--- a/Aikido.Zen.Tests.DotNetFramework/BlockingModuleTests.cs
+++ b/Aikido.Zen.Tests.DotNetFramework/BlockingModuleTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Web;
 using Aikido.Zen.Core;
 using Aikido.Zen.Core.Models;
@@ -73,6 +72,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
                 var httpContext = new HttpContext(
                     new HttpRequest(string.Empty, "http://test.local/api/test", string.Empty),
                     new HttpResponse(output));
+                HttpContext.Current = httpContext;
                 var aikidoContext = new Context
                 {
                     Url = "http://test.local/api/test",
@@ -87,13 +87,9 @@ namespace Aikido.Zen.Tests.DotNetFramework
 
                 BlockingModule.HandleBlocking(httpContext, () => completed = true);
 
-                var capturedUser = Agent.Instance.Context.Users.SingleOrDefault(u => u.Id == user.Id);
-
                 Assert.Multiple(() =>
                 {
-                    Assert.That(capturedUser, Is.Not.Null);
-                    Assert.That(capturedUser.Name, Is.EqualTo(user.Name));
-                    Assert.That(capturedUser.LastIpAddress, Is.EqualTo("127.0.0.1"));
+                    Assert.That(Agent.Instance.Context.Users, Is.Empty);
                     Assert.That(httpContext.Response.StatusCode, Is.EqualTo(403));
                     Assert.That(output.ToString(), Is.EqualTo("Your request is blocked: User is blocked"));
                     Assert.That(completed, Is.True);
@@ -102,6 +98,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
             finally
             {
                 FrameworkZen.ClearCurrentContext();
+                HttpContext.Current = null;
                 Agent.Instance.ClearContext();
                 Agent.Instance.Context.Config.UpdateBlockedUsers(System.Array.Empty<string>());
             }

--- a/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
+++ b/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
@@ -287,6 +287,7 @@ namespace Aikido.Zen.Tests.DotNetFramework
                 var httpContext = new HttpContext(
                     new HttpRequest(string.Empty, "http://test.local/api/test", string.Empty),
                     new HttpResponse(new StringWriter()));
+                HttpContext.Current = httpContext;
                 var aikidoContext = new Context
                 {
                     Url = "http://test.local/api/test",
@@ -312,8 +313,55 @@ namespace Aikido.Zen.Tests.DotNetFramework
             finally
             {
                 Aikido.Zen.DotNetFramework.Zen.ClearCurrentContext();
+                HttpContext.Current = null;
                 Aikido.Zen.DotNetFramework.Zen.SetUserAction = originalSetUserAction;
                 Agent.Instance.ClearContext();
+            }
+        }
+
+        [Test]
+        public void PopulateAuthenticatedUser_ThenHandleBlocking_CapturesUserOnce()
+        {
+            Agent.Instance.ClearContext();
+            Agent.Instance.Context.Config.UpdateBlockedUsers(new[] { "blocked-user" });
+            var originalSetUserAction = Aikido.Zen.DotNetFramework.Zen.SetUserAction;
+
+            try
+            {
+                var user = new User("blocked-user", "Blocked User");
+                var httpContext = new HttpContext(
+                    new HttpRequest(string.Empty, "http://test.local/api/test", string.Empty),
+                    new HttpResponse(new StringWriter()));
+                HttpContext.Current = httpContext;
+                var aikidoContext = new Context
+                {
+                    Url = "http://test.local/api/test",
+                    Path = "/api/test",
+                    Method = "GET",
+                    Route = "/api/test",
+                    RemoteAddress = "127.0.0.1"
+                };
+                Aikido.Zen.DotNetFramework.Zen.SetCurrentContext(aikidoContext);
+                Aikido.Zen.DotNetFramework.Zen.SetUserAction = _ => user;
+
+                ContextModule.PopulateAuthenticatedUser(httpContext);
+                BlockingModule.HandleBlocking(httpContext, () => { });
+
+                var capturedUser = Agent.Instance.Context.Users.Single(u => u.Id == user.Id);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(capturedUser.Hits, Is.EqualTo(1));
+                    Assert.That(httpContext.Response.StatusCode, Is.EqualTo(403));
+                });
+            }
+            finally
+            {
+                Aikido.Zen.DotNetFramework.Zen.ClearCurrentContext();
+                HttpContext.Current = null;
+                Aikido.Zen.DotNetFramework.Zen.SetUserAction = originalSetUserAction;
+                Agent.Instance.ClearContext();
+                Agent.Instance.Context.Config.UpdateBlockedUsers(Array.Empty<string>());
             }
         }
 


### PR DESCRIPTION
This PR fixes user capture across the middleware lifecycle:
- Captures each request’s final user once, at request completion.
- Detects late SetUser calls and emits one middleware-order warning.
- Still reports late users, while clarifying that blocking and rate limiting cannot run retroactively.
- Removes duplicate user capture from BlockingMiddleware.
- Simplifies the internal capture API and removes obsolete request flags.
- Removes redundant .NET Framework capture and raw user-ID logging.
- Adds coverage for middleware ordering, bypassed requests, resolved client IPs, late users, and duplicate prevention.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Detected late SetUser calls and emitted a single ordering warning
* Allowed SetUser on bypassed request contexts while preserving late users

**🐛 Bugfixes**
* Removed duplicate user capture from blocking middleware to prevent duplication
* Captured each request's final user once at request completion

**🔧 Refactors**
* Simplified internal capture API and removed obsolete request flags


<sup>[More info](https://app.aikido.dev/featurebranch/scan/147681327?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->