### PR TITLE
Avoid deadlock during .NET Framework request capture

### DIFF
--- a/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
+++ b/Aikido.Zen.DotNetFramework/HttpModules/ContextModule.cs
@@ -31,7 +31,8 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
         {
             LogHelper.DebugLog(Agent.Logger, "ContextModule initialized");
             context.PostAuthenticateRequest += Context_PostAuthenticateRequest;
-            context.BeginRequest += Context_BeginRequest;
+            var beginRequestHelper = new EventHandlerTaskAsyncHelper(Context_BeginRequestAsync);
+            context.AddOnBeginRequestAsync(beginRequestHelper.BeginEventHandler, beginRequestHelper.EndEventHandler);
             context.EndRequest += Context_EndRequest;
         }
 
@@ -76,7 +77,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
             }
         }
 
-        private void Context_BeginRequest(object sender, EventArgs e)
+        private async Task Context_BeginRequestAsync(object sender, EventArgs e)
         {
             LogHelper.DebugLog(Agent.Logger, "Capturing request context");
             var httpContext = ((HttpApplication)sender).Context;
@@ -115,7 +116,7 @@ namespace Aikido.Zen.DotNetFramework.HttpModules
                 Zen.SetCurrentContext(context);
                 Agent.Instance.SetContextMiddlewareInstalled(true);
 
-                Task.Run(() => ReadAndCaptureHttpDataAsync(httpContext, context)).Wait();
+                await ReadAndCaptureHttpDataAsync(httpContext, context);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary

- register request capture with `EventHandlerTaskAsyncHelper` and `AddOnBeginRequestAsync`
- await request-body capture directly instead of blocking on `Task.Run(...).Wait()`
- keep request context creation, body parsing, and stream rewinding in the ASP.NET request pipeline

## Why

The synchronous `BeginRequest` handler blocked the ASP.NET request thread while waiting for asynchronous request-body reads. Under IIS/System.Web, a JSON body read can require the request pipeline to make progress, producing a deadlock while the pipeline thread is blocked.

Using ASP.NET's asynchronous event registration lets the pipeline track and await request capture without synchronously blocking its request thread.

## Validation

- `dotnet cake build.cake --target=Test --framework=4.8 --configuration=Release --downloadRetries=3 --downloadRetryDelaySeconds=1` completed successfully (build and core test target)
- direct Visual Studio test execution discovered 24 .NET Framework tests: 22 passed; the same 2 ambient-context tests fail on unmodified `main`
- IIS/Compose JSON regression: the previously hanging POST completed in 0.634s and a follow-up GET succeeded
- request-context benchmark and slow-upload checks completed without a deadlock and preserved context propagation

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Replaced synchronous BeginRequest handler with asynchronous EventHandlerTaskAsyncHelper registration

**🔧 Refactors**
* Awaited request-body capture directly instead of blocking Task.Run().Wait()


<sup>[More info](https://app.aikido.dev/featurebranch/scan/148334134?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->