### PR TITLE
Update firewall tester action

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -104,4 +104,5 @@ jobs:
           build_args: |
             MSBUILD_ARGS=/nologo /p:AikidoZenDotNetFrameworkVersion=0.0.0-qa
           app_port: 80
+          max_parallel_tests: 20
           sleep_before_test: 15

--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -70,7 +70,7 @@ jobs:
 
   qa-tests-netfx:
     needs: build-package
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 60
     steps:
       - name: Checkout zen-demo-dotnet-framework

--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -60,7 +60,7 @@ jobs:
           path: zen-demo-dotnet-core/local-feed
 
       - name: Run Firewall QA Tests
-        uses: AikidoSec/firewall-tester-action@772517cb217f3432cb48d1087d07fa8e2a0bf2f9
+        uses: AikidoSec/firewall-tester-action@eb08774ef9d9345335fcf08b3e79beaa40180b1f
         with:
           dockerfile_path: ./zen-demo-dotnet-core/Dockerfile
           build_args: |
@@ -98,7 +98,7 @@ jobs:
           Write-Host "Ensured inbound firewall rule for TCP 3000 on all profiles."
 
       - name: Run Firewall QA Tests
-        uses: AikidoSec/firewall-tester-action@772517cb217f3432cb48d1087d07fa8e2a0bf2f9
+        uses: AikidoSec/firewall-tester-action@eb08774ef9d9345335fcf08b3e79beaa40180b1f
         with:
           dockerfile_path: ./zen-demo-dotnet-framework/Dockerfile
           build_args: |


### PR DESCRIPTION
## Summary

- update both .NET Core and .NET Framework QA jobs to pin firewall-tester-action commit `eb08774ef9d9345335fcf08b3e79beaa40180b1f`
- let .NET Core inherit the action default of 50 parallel tests
- cap .NET Framework at 20 parallel tests on the Windows Server 2025 runner

## Why

The updated action runs the Compose-native test suite. A first PR run with 50-way parallelism passed all 34 .NET Core tests, but the .NET Framework job passed 33/34 and was slower than the previous 10-way run. Under load, repeated app-readiness timeouts consumed the failing rate-limit test's request budget before its assertions began.

Using 20 keeps more parallelism than the previous default while reducing Windows-container contention.

## Validation

- `git diff --check`
- verified the pinned commit exists in `AikidoSec/firewall-tester-action`
- previous .NET Framework run at 10: 34/34 passed
- first PR run at 50: 33/34 passed; `test-user-rate-limiting-1-minute-without-x-forwarded-for` failed
- updated 20-way CI run is pending

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Pinned firewall-tester-action to a specific commit for both jobs
* Capped .NET Framework QA parallelism by adding max_parallel_tests: 20
* Changed .NET Framework QA runner to use windows-2022 instead of latest


<sup>[More info](https://app.aikido.dev/featurebranch/scan/148969887?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->