### PR TITLE
Add realtime configuration updates via SSE

### DIFF
--- a/Aikido.Zen.Benchmarks/PatchBenchmarks.cs
+++ b/Aikido.Zen.Benchmarks/PatchBenchmarks.cs
@@ -123,6 +123,14 @@ namespace Aikido.Zen.Benchmarks
             {
                 return Task.FromResult(new ReportingAPIResponse { Success = true });
             }
+
+            public Task<HttpStatusCode> SubscribeToConfigUpdates(
+                string token,
+                Func<long, Task> onUpdate,
+                CancellationToken cancellationToken)
+            {
+                return Task.FromResult(HttpStatusCode.Unauthorized);
+            }
         }
     }
 }

--- a/Aikido.Zen.Core/Agent.cs
+++ b/Aikido.Zen.Core/Agent.cs
@@ -27,8 +27,8 @@ namespace Aikido.Zen.Core
         private readonly CancellationTokenSource _cancellationSource;
         private readonly Task _backgroundTask;
         private readonly ConcurrentDictionary<string, ScheduledItem> _scheduledEvents;
-        private readonly object _realtimeConfigTaskLock = new object();
         private Task _realtimeConfigTask;
+        private int _configCheckRequested;
         internal DateTime LastConfigCheck { get; set; } = DateTime.UtcNow;
         public static ILogger Logger = new DefaultLogger();
 
@@ -275,14 +275,8 @@ namespace Aikido.Zen.Core
                     // pass through
                 }
 
-                Task realtimeConfigTask;
-                lock (_realtimeConfigTaskLock)
-                {
-                    realtimeConfigTask = _realtimeConfigTask;
-                }
-
-                if (realtimeConfigTask != null &&
-                    !realtimeConfigTask.Wait(TimeSpan.FromSeconds(30)))
+                if (_realtimeConfigTask != null &&
+                    !_realtimeConfigTask.Wait(TimeSpan.FromSeconds(30)))
                 {
                     // pass through
                 }
@@ -459,8 +453,9 @@ namespace Aikido.Zen.Core
             {
                 try
                 {
-                    // check for config updates every minute
-                    if (LastConfigCheck + TimeSpan.FromMinutes(1) < DateTime.UtcNow)
+                    // check for config updates when requested or every minute
+                    var configCheckRequested = Interlocked.Exchange(ref _configCheckRequested, 0) == 1;
+                    if (configCheckRequested || LastConfigCheck + TimeSpan.FromMinutes(1) < DateTime.UtcNow)
                     {
                         LastConfigCheck = DateTime.UtcNow;
                         if (ConfigChanged(out var response))
@@ -644,26 +639,16 @@ namespace Aikido.Zen.Core
             return latestConfig.Success;
         }
 
-        private async Task RefreshConfigIfNewerAsync(long configUpdatedAt)
+        private Task QueueConfigCheck(long configUpdatedAt)
         {
             LogHelper.DebugLog(Logger, "Realtime config update received");
 
-            if (configUpdatedAt <= _context.Config.ConfigLastUpdated)
+            if (configUpdatedAt > _context.Config.ConfigLastUpdated)
             {
-                return;
+                Interlocked.Exchange(ref _configCheckRequested, 1);
             }
 
-            var latestConfig = await _api.Runtime.GetConfig(
-                EnvironmentHelper.Token,
-                _cancellationSource.Token).ConfigureAwait(false);
-            if (!latestConfig.Success ||
-                latestConfig.ConfigUpdatedAt <= _context.Config.ConfigLastUpdated)
-            {
-                return;
-            }
-
-            UpdateConfig(latestConfig);
-            await UpdateFirewallLists().ConfigureAwait(false);
+            return Task.CompletedTask;
         }
 
         private void StartRealtimeConfigUpdates()
@@ -675,19 +660,16 @@ namespace Aikido.Zen.Core
                 return;
             }
 
-            lock (_realtimeConfigTaskLock)
+            if (_realtimeConfigTask != null)
             {
-                if (_realtimeConfigTask != null)
-                {
-                    return;
-                }
-
-                _realtimeConfigTask = RealtimeConfigUpdateListener.RunAsync(
-                    _api.Runtime,
-                    EnvironmentHelper.Token,
-                    RefreshConfigIfNewerAsync,
-                    _cancellationSource.Token);
+                return;
             }
+
+            _realtimeConfigTask = new RealtimeConfigUpdateListener().RunAsync(
+                _api.Runtime,
+                EnvironmentHelper.Token,
+                QueueConfigCheck,
+                _cancellationSource.Token);
         }
 
         private void UpdateConfig(ReportingAPIResponse response)

--- a/Aikido.Zen.Core/Agent.cs
+++ b/Aikido.Zen.Core/Agent.cs
@@ -8,6 +8,7 @@ using Aikido.Zen.Core.Api;
 using Aikido.Zen.Core.Helpers;
 using Aikido.Zen.Core.Models;
 using Aikido.Zen.Core.Models.Events;
+using Aikido.Zen.Core.Realtime;
 using Aikido.Zen.Core.Vulnerabilities;
 using Microsoft.Extensions.Logging;
 
@@ -26,6 +27,8 @@ namespace Aikido.Zen.Core
         private readonly CancellationTokenSource _cancellationSource;
         private readonly Task _backgroundTask;
         private readonly ConcurrentDictionary<string, ScheduledItem> _scheduledEvents;
+        private readonly object _realtimeConfigTaskLock = new object();
+        private Task _realtimeConfigTask;
         internal DateTime LastConfigCheck { get; set; } = DateTime.UtcNow;
         public static ILogger Logger = new DefaultLogger();
 
@@ -122,11 +125,18 @@ namespace Aikido.Zen.Core
             QueueEvent(EnvironmentHelper.Token, Started.Create(),
             (evt, response) =>
             {
-                if (response.Success)
+                try
                 {
-                    var reportingResponse = response as ReportingAPIResponse;
-                    UpdateConfig(reportingResponse);
-                    UpdateFirewallLists().GetAwaiter().GetResult();
+                    if (response.Success)
+                    {
+                        var reportingResponse = response as ReportingAPIResponse;
+                        UpdateConfig(reportingResponse);
+                        UpdateFirewallLists().GetAwaiter().GetResult();
+                    }
+                }
+                finally
+                {
+                    StartRealtimeConfigUpdates();
                 }
             });
 
@@ -261,6 +271,18 @@ namespace Aikido.Zen.Core
 
                 // Wait for background task to complete gracefully
                 if (!_backgroundTask.Wait(TimeSpan.FromSeconds(30)))
+                {
+                    // pass through
+                }
+
+                Task realtimeConfigTask;
+                lock (_realtimeConfigTaskLock)
+                {
+                    realtimeConfigTask = _realtimeConfigTask;
+                }
+
+                if (realtimeConfigTask != null &&
+                    !realtimeConfigTask.Wait(TimeSpan.FromSeconds(30)))
                 {
                     // pass through
                 }
@@ -620,6 +642,52 @@ namespace Aikido.Zen.Core
 
             // Trigger config change if new configuration retrieved successfully
             return latestConfig.Success;
+        }
+
+        private async Task RefreshConfigIfNewerAsync(long configUpdatedAt)
+        {
+            LogHelper.DebugLog(Logger, "Realtime config update received");
+
+            if (configUpdatedAt <= _context.Config.ConfigLastUpdated)
+            {
+                return;
+            }
+
+            var latestConfig = await _api.Runtime.GetConfig(
+                EnvironmentHelper.Token,
+                _cancellationSource.Token).ConfigureAwait(false);
+            if (!latestConfig.Success ||
+                latestConfig.ConfigUpdatedAt <= _context.Config.ConfigLastUpdated)
+            {
+                return;
+            }
+
+            UpdateConfig(latestConfig);
+            await UpdateFirewallLists().ConfigureAwait(false);
+        }
+
+        private void StartRealtimeConfigUpdates()
+        {
+            if (!EnvironmentHelper.RealtimeConfigUpdatesEnabled ||
+                string.IsNullOrEmpty(EnvironmentHelper.Token) ||
+                _cancellationSource.IsCancellationRequested)
+            {
+                return;
+            }
+
+            lock (_realtimeConfigTaskLock)
+            {
+                if (_realtimeConfigTask != null)
+                {
+                    return;
+                }
+
+                _realtimeConfigTask = RealtimeConfigUpdateListener.RunAsync(
+                    _api.Runtime,
+                    EnvironmentHelper.Token,
+                    RefreshConfigIfNewerAsync,
+                    _cancellationSource.Token);
+            }
         }
 
         private void UpdateConfig(ReportingAPIResponse response)

--- a/Aikido.Zen.Core/Api/IRuntime.cs
+++ b/Aikido.Zen.Core/Api/IRuntime.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,5 +9,6 @@ namespace Aikido.Zen.Core.Api
     {
         Task<ConfigLastUpdatedAPIResponse> GetConfigLastUpdated(string token, CancellationToken cancellationToken);
         Task<ReportingAPIResponse> GetConfig(string token, CancellationToken cancellationToken);
+        Task<HttpStatusCode> SubscribeToConfigUpdates(string token, Func<long, Task> onUpdate, CancellationToken cancellationToken);
     }
 }

--- a/Aikido.Zen.Core/Api/Runtime.cs
+++ b/Aikido.Zen.Core/Api/Runtime.cs
@@ -66,11 +66,6 @@ namespace Aikido.Zen.Core.Api
             Func<long, Task> onUpdate,
             CancellationToken cancellationToken)
         {
-            if (onUpdate == null)
-            {
-                throw new ArgumentNullException(nameof(onUpdate));
-            }
-
             using (var request = APIHelper.CreateRequest(
                 token,
                 new Uri(EnvironmentHelper.AikidoRealtimeUrl),

--- a/Aikido.Zen.Core/Api/Runtime.cs
+++ b/Aikido.Zen.Core/Api/Runtime.cs
@@ -95,7 +95,10 @@ namespace Aikido.Zen.Core.Api
 
                         while (!cancellationToken.IsCancellationRequested)
                         {
-                            var line = await ReadLineWithTimeout(reader, cancellationToken).ConfigureAwait(false);
+                            var line = await WaitForLineOrTimeout(
+                                reader.ReadLineAsync(),
+                                cancellationToken,
+                                SseReadTimeout).ConfigureAwait(false);
                             if (line == null)
                             {
                                 return response.StatusCode;
@@ -132,15 +135,14 @@ namespace Aikido.Zen.Core.Api
             }
         }
 
-        private static async Task<string> ReadLineWithTimeout(
-            StreamReader reader,
-            CancellationToken cancellationToken)
+        internal static async Task<string> WaitForLineOrTimeout(
+            Task<string> readTask,
+            CancellationToken cancellationToken,
+            TimeSpan timeout)
         {
-            var readTask = reader.ReadLineAsync();
-
             using (var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
             {
-                var timeoutTask = Task.Delay(SseReadTimeout, timeoutSource.Token);
+                var timeoutTask = Task.Delay(timeout, timeoutSource.Token);
                 var completedTask = await Task.WhenAny(readTask, timeoutTask).ConfigureAwait(false);
 
                 if (completedTask == readTask)

--- a/Aikido.Zen.Core/Api/Runtime.cs
+++ b/Aikido.Zen.Core/Api/Runtime.cs
@@ -1,13 +1,19 @@
 using System;
+using System.IO;
+using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Aikido.Zen.Core.Helpers;
+using Aikido.Zen.Core.Realtime;
 
 namespace Aikido.Zen.Core.Api
 {
     internal class RuntimeAPIClient : IRuntimeAPIClient
     {
+        private static readonly TimeSpan SseReadTimeout = TimeSpan.FromSeconds(70);
         private readonly HttpClient _httpClient;
 
         public RuntimeAPIClient(HttpClient httpClient)
@@ -53,6 +59,104 @@ namespace Aikido.Zen.Core.Api
                 LogHelper.WarningLog(Agent.Logger, ex, "Failed to retrieve config");
                 return new ReportingAPIResponse { Success = false, Error = "unknown_error" };
             }
+        }
+
+        public async Task<HttpStatusCode> SubscribeToConfigUpdates(
+            string token,
+            Func<long, Task> onUpdate,
+            CancellationToken cancellationToken)
+        {
+            if (onUpdate == null)
+            {
+                throw new ArgumentNullException(nameof(onUpdate));
+            }
+
+            using (var request = APIHelper.CreateRequest(
+                token,
+                new Uri(EnvironmentHelper.AikidoRealtimeUrl),
+                "/api/runtime/stream",
+                HttpMethod.Get))
+            {
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+                request.Headers.AcceptEncoding.Clear();
+                request.Headers.CacheControl = new CacheControlHeaderValue { NoCache = true };
+                request.Headers.Add("X-Agent-Platform", "dotnet");
+                request.Headers.Add("X-Agent-Version", AgentInfoHelper.ZenVersion);
+
+                using (var response = await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    cancellationToken).ConfigureAwait(false))
+                {
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        return response.StatusCode;
+                    }
+
+                    using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                    using (var reader = new StreamReader(stream))
+                    {
+                        var parser = new SseParser();
+
+                        while (!cancellationToken.IsCancellationRequested)
+                        {
+                            var line = await ReadLineWithTimeout(reader, cancellationToken).ConfigureAwait(false);
+                            if (line == null)
+                            {
+                                return response.StatusCode;
+                            }
+
+                            if (!parser.TryProcessLine(line, out var eventName, out var data) ||
+                                eventName != "config-updated")
+                            {
+                                continue;
+                            }
+
+                            try
+                            {
+                                var payload = JsonSerializer.Deserialize<ConfigLastUpdatedAPIResponse>(
+                                    data,
+                                    ZenApi.JsonSerializerOptions);
+                                if (payload != null)
+                                {
+                                    await onUpdate(payload.ConfigUpdatedAt).ConfigureAwait(false);
+                                }
+                            }
+                            catch (JsonException ex)
+                            {
+                                LogHelper.DebugLog(
+                                    Agent.Logger,
+                                    ex,
+                                    "Ignoring invalid realtime config update payload");
+                            }
+                        }
+                    }
+
+                    return response.StatusCode;
+                }
+            }
+        }
+
+        private static async Task<string> ReadLineWithTimeout(
+            StreamReader reader,
+            CancellationToken cancellationToken)
+        {
+            var readTask = reader.ReadLineAsync();
+
+            using (var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+            {
+                var timeoutTask = Task.Delay(SseReadTimeout, timeoutSource.Token);
+                var completedTask = await Task.WhenAny(readTask, timeoutTask).ConfigureAwait(false);
+
+                if (completedTask == readTask)
+                {
+                    timeoutSource.Cancel();
+                    return await readTask.ConfigureAwait(false);
+                }
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new TimeoutException("Realtime config connection did not receive data before the read timeout");
         }
     }
 }

--- a/Aikido.Zen.Core/Api/Runtime.cs
+++ b/Aikido.Zen.Core/Api/Runtime.cs
@@ -78,6 +78,8 @@ namespace Aikido.Zen.Core.Api
                 request.Headers.Add("X-Agent-Platform", "dotnet");
                 request.Headers.Add("X-Agent-Version", AgentInfoHelper.ZenVersion);
 
+                // ResponseHeadersRead limits HttpClient.Timeout to receiving the headers;
+                // stream inactivity is handled separately by SseReadTimeout.
                 using (var response = await _httpClient.SendAsync(
                     request,
                     HttpCompletionOption.ResponseHeadersRead,

--- a/Aikido.Zen.Core/Helpers/EnvironmentHelper.cs
+++ b/Aikido.Zen.Core/Helpers/EnvironmentHelper.cs
@@ -67,6 +67,12 @@ namespace Aikido.Zen.Core.Helpers
         public static bool DisableEndpointRoutingCheck => GetBooleanValue("AIKIDO_DISABLE_ENDPOINT_ROUTING_CHECK");
 
         /// <summary>
+        /// Determines whether realtime SSE config notifications are enabled.
+        /// The one-minute config poll remains active as a fallback.
+        /// </summary>
+        public static bool RealtimeConfigUpdatesEnabled => GetBooleanValue("AIKIDO_FEATURE_SSE");
+
+        /// <summary>
         /// Helper method to determine if an environment variable is set to "true" or "1".
         /// </summary>
         /// <param name="variableName">The name of the environment variable to check.</param>

--- a/Aikido.Zen.Core/Realtime/RealtimeConfigUpdateListener.cs
+++ b/Aikido.Zen.Core/Realtime/RealtimeConfigUpdateListener.cs
@@ -7,27 +7,28 @@ using Aikido.Zen.Core.Helpers;
 
 namespace Aikido.Zen.Core.Realtime
 {
-    internal static class RealtimeConfigUpdateListener
+    internal sealed class RealtimeConfigUpdateListener
     {
+        private static readonly TimeSpan InitialReconnectDelay = TimeSpan.FromSeconds(5);
         private static readonly TimeSpan MaxReconnectDelay = TimeSpan.FromSeconds(60);
         private static readonly TimeSpan StableConnectionThreshold = TimeSpan.FromSeconds(30);
 
-        internal static async Task RunAsync(
+        internal TimeSpan ReconnectDelay { get; set; } = InitialReconnectDelay;
+        internal DateTime ConnectionStartedAt { get; set; }
+
+        internal async Task RunAsync(
             IRuntimeAPIClient runtimeApi,
             string token,
             Func<long, Task> onUpdate,
-            CancellationToken cancellationToken,
-            TimeSpan? initialReconnectDelay = null)
+            CancellationToken cancellationToken)
         {
-            var initialDelay = initialReconnectDelay ?? TimeSpan.FromSeconds(5);
-            var reconnectDelay = initialDelay;
             var random = new Random();
 
             try
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    var connectedAt = DateTime.UtcNow;
+                    ConnectionStartedAt = DateTime.UtcNow;
 
                     try
                     {
@@ -60,17 +61,17 @@ namespace Aikido.Zen.Core.Realtime
                             "Realtime config connection failed; reconnecting");
                     }
 
-                    if (DateTime.UtcNow - connectedAt >= StableConnectionThreshold)
+                    if (DateTime.UtcNow - ConnectionStartedAt >= StableConnectionThreshold)
                     {
-                        reconnectDelay = initialDelay;
+                        ReconnectDelay = InitialReconnectDelay;
                     }
 
                     var jitter = TimeSpan.FromMilliseconds(
-                        reconnectDelay.TotalMilliseconds * random.NextDouble() / 2);
-                    await Task.Delay(reconnectDelay + jitter, cancellationToken).ConfigureAwait(false);
+                        ReconnectDelay.TotalMilliseconds * random.NextDouble() / 2);
+                    await Task.Delay(ReconnectDelay + jitter, cancellationToken).ConfigureAwait(false);
 
-                    reconnectDelay = TimeSpan.FromTicks(Math.Min(
-                        reconnectDelay.Ticks * 2,
+                    ReconnectDelay = TimeSpan.FromTicks(Math.Min(
+                        ReconnectDelay.Ticks * 2,
                         MaxReconnectDelay.Ticks));
                 }
             }

--- a/Aikido.Zen.Core/Realtime/RealtimeConfigUpdateListener.cs
+++ b/Aikido.Zen.Core/Realtime/RealtimeConfigUpdateListener.cs
@@ -19,10 +19,6 @@ namespace Aikido.Zen.Core.Realtime
             CancellationToken cancellationToken,
             TimeSpan? initialReconnectDelay = null)
         {
-            runtimeApi = runtimeApi ?? throw new ArgumentNullException(nameof(runtimeApi));
-            token = token ?? throw new ArgumentNullException(nameof(token));
-            onUpdate = onUpdate ?? throw new ArgumentNullException(nameof(onUpdate));
-
             var initialDelay = initialReconnectDelay ?? TimeSpan.FromSeconds(5);
             var reconnectDelay = initialDelay;
             var random = new Random();

--- a/Aikido.Zen.Core/Realtime/RealtimeConfigUpdateListener.cs
+++ b/Aikido.Zen.Core/Realtime/RealtimeConfigUpdateListener.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Aikido.Zen.Core.Api;
+using Aikido.Zen.Core.Helpers;
+
+namespace Aikido.Zen.Core.Realtime
+{
+    internal static class RealtimeConfigUpdateListener
+    {
+        private static readonly TimeSpan MaxReconnectDelay = TimeSpan.FromSeconds(60);
+        private static readonly TimeSpan StableConnectionThreshold = TimeSpan.FromSeconds(30);
+
+        internal static async Task RunAsync(
+            IRuntimeAPIClient runtimeApi,
+            string token,
+            Func<long, Task> onUpdate,
+            CancellationToken cancellationToken,
+            TimeSpan? initialReconnectDelay = null)
+        {
+            runtimeApi = runtimeApi ?? throw new ArgumentNullException(nameof(runtimeApi));
+            token = token ?? throw new ArgumentNullException(nameof(token));
+            onUpdate = onUpdate ?? throw new ArgumentNullException(nameof(onUpdate));
+
+            var initialDelay = initialReconnectDelay ?? TimeSpan.FromSeconds(5);
+            var reconnectDelay = initialDelay;
+            var random = new Random();
+
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var connectedAt = DateTime.UtcNow;
+
+                    try
+                    {
+                        var statusCode = await runtimeApi.SubscribeToConfigUpdates(
+                            token,
+                            onUpdate,
+                            cancellationToken).ConfigureAwait(false);
+
+                        if (statusCode == HttpStatusCode.Unauthorized ||
+                            statusCode == HttpStatusCode.Forbidden)
+                        {
+                            LogHelper.WarningLog(
+                                Agent.Logger,
+                                $"Realtime config connection rejected with status {(int)statusCode}; stopping");
+                            return;
+                        }
+
+                        LogHelper.DebugLog(Agent.Logger, "Realtime config connection closed; reconnecting");
+                    }
+                    catch (Exception ex)
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            return;
+                        }
+
+                        LogHelper.DebugLog(
+                            Agent.Logger,
+                            ex,
+                            "Realtime config connection failed; reconnecting");
+                    }
+
+                    if (DateTime.UtcNow - connectedAt >= StableConnectionThreshold)
+                    {
+                        reconnectDelay = initialDelay;
+                    }
+
+                    var jitter = TimeSpan.FromMilliseconds(
+                        reconnectDelay.TotalMilliseconds * random.NextDouble() / 2);
+                    await Task.Delay(reconnectDelay + jitter, cancellationToken).ConfigureAwait(false);
+
+                    reconnectDelay = TimeSpan.FromTicks(Math.Min(
+                        reconnectDelay.Ticks * 2,
+                        MaxReconnectDelay.Ticks));
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+        }
+    }
+}

--- a/Aikido.Zen.Core/Realtime/SseParser.cs
+++ b/Aikido.Zen.Core/Realtime/SseParser.cs
@@ -15,7 +15,7 @@ namespace Aikido.Zen.Core.Realtime
 
             if (_isFirstLine)
             {
-                line = line?.TrimStart('\uFEFF');
+                line = line.TrimStart('\uFEFF');
                 _isFirstLine = false;
             }
 

--- a/Aikido.Zen.Core/Realtime/SseParser.cs
+++ b/Aikido.Zen.Core/Realtime/SseParser.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+
+namespace Aikido.Zen.Core.Realtime
+{
+    internal sealed class SseParser
+    {
+        private string _eventName;
+        private readonly List<string> _dataLines = new List<string>();
+        private bool _isFirstLine = true;
+
+        internal bool TryProcessLine(string line, out string eventName, out string data)
+        {
+            eventName = null;
+            data = null;
+
+            if (_isFirstLine)
+            {
+                line = line?.TrimStart('\uFEFF');
+                _isFirstLine = false;
+            }
+
+            if (string.IsNullOrEmpty(line))
+            {
+                if (_dataLines.Count == 0)
+                {
+                    ResetEvent();
+                    return false;
+                }
+
+                eventName = _eventName;
+                data = string.Join("\n", _dataLines);
+                ResetEvent();
+                return true;
+            }
+
+            if (line[0] == ':')
+            {
+                return false;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            var field = separatorIndex >= 0 ? line.Substring(0, separatorIndex) : line;
+            var value = separatorIndex >= 0 ? line.Substring(separatorIndex + 1) : string.Empty;
+            if (value.StartsWith(" "))
+            {
+                value = value.Substring(1);
+            }
+
+            switch (field)
+            {
+                case "event":
+                    _eventName = value;
+                    break;
+                case "data":
+                    _dataLines.Add(value);
+                    break;
+            }
+
+            return false;
+        }
+
+        private void ResetEvent()
+        {
+            _eventName = null;
+            _dataLines.Clear();
+        }
+    }
+}

--- a/Aikido.Zen.Test.End2End/RealtimeConfigUpdateTests.cs
+++ b/Aikido.Zen.Test.End2End/RealtimeConfigUpdateTests.cs
@@ -15,8 +15,6 @@ namespace Aikido.Zen.Test.End2End
     [NonParallelizable]
     public class RealtimeConfigUpdateTests : WebApplicationTestBase
     {
-        private WebApplicationFactory<SQLiteStartup>? _sampleAppFactory;
-
         protected override Task SetupDatabaseContainers()
         {
             return Task.CompletedTask;
@@ -29,15 +27,14 @@ namespace Aikido.Zen.Test.End2End
             SampleAppEnvironmentVariables["AIKIDO_FEATURE_SSE"] = "true";
             await SetMode(disabled: false, block: true);
 
-            _sampleAppFactory = new WebApplicationFactory<SQLiteStartup>()
-                .WithWebHostBuilder(ConfigureSampleApp);
-            SampleAppClient = _sampleAppFactory.CreateClient();
+            SampleAppClient = new WebApplicationFactory<SQLiteStartup>()
+                .WithWebHostBuilder(ConfigureSampleApp)
+                .CreateClient();
         }
 
         [OneTimeTearDown]
         public override async Task OneTimeTearDown()
         {
-            _sampleAppFactory?.Dispose();
             Environment.SetEnvironmentVariable("AIKIDO_FEATURE_SSE", null);
             await base.OneTimeTearDown();
         }

--- a/Aikido.Zen.Test.End2End/RealtimeConfigUpdateTests.cs
+++ b/Aikido.Zen.Test.End2End/RealtimeConfigUpdateTests.cs
@@ -1,0 +1,190 @@
+using Aikido.Zen.DotNetCore;
+using Aikido.Zen.Core;
+using Aikido.Zen.Server.Mock.Models;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using NUnit.Framework;
+using SQLiteSampleApp;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Aikido.Zen.Test.End2End
+{
+    [TestFixture]
+    [NonParallelizable]
+    public class RealtimeConfigUpdateTests : WebApplicationTestBase
+    {
+        private WebApplicationFactory<SQLiteStartup>? _sampleAppFactory;
+
+        protected override Task SetupDatabaseContainers()
+        {
+            return Task.CompletedTask;
+        }
+
+        [OneTimeSetUp]
+        public override async Task OneTimeSetUp()
+        {
+            await base.OneTimeSetUp();
+            SampleAppEnvironmentVariables["AIKIDO_FEATURE_SSE"] = "true";
+            await SetMode(disabled: false, block: true);
+
+            _sampleAppFactory = new WebApplicationFactory<SQLiteStartup>()
+                .WithWebHostBuilder(ConfigureSampleApp);
+            SampleAppClient = _sampleAppFactory.CreateClient();
+        }
+
+        [OneTimeTearDown]
+        public override async Task OneTimeTearDown()
+        {
+            _sampleAppFactory?.Dispose();
+            Environment.SetEnvironmentVariable("AIKIDO_FEATURE_SSE", null);
+            await base.OneTimeTearDown();
+        }
+
+        [Test]
+        public async Task MockRealtimeStream_EmitsConfigUpdates()
+        {
+            using var cancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var streamRequest = new HttpRequestMessage(
+                HttpMethod.Get,
+                "/api/runtime/stream");
+            using var streamResponse = await MockServerClient.SendAsync(
+                streamRequest,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationSource.Token);
+            streamResponse.EnsureSuccessStatusCode();
+
+            using var stream = await streamResponse.Content.ReadAsStreamAsync(cancellationSource.Token);
+            using var reader = new StreamReader(stream);
+            var initialTimestamp = await ReadConfigUpdatedAt(reader, cancellationSource.Token);
+
+            await MockServerClient.PostAsJsonAsync(
+                "/api/runtime/config",
+                new Dictionary<string, object> { ["block"] = true },
+                cancellationSource.Token);
+
+            var updatedTimestamp = await ReadConfigUpdatedAt(reader, cancellationSource.Token);
+
+            Assert.That(updatedTimestamp, Is.GreaterThan(initialTimestamp));
+        }
+
+        [Test]
+        public async Task FirewallListUpdate_IsAppliedThroughRealtimeStream()
+        {
+            const string blockedIp = "123.123.123.124";
+
+            using (var beforeRequest = CreateRequest(blockedIp))
+            using (var beforeResponse = await SampleAppClient.SendAsync(beforeRequest))
+            {
+                Assert.That(beforeResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            }
+
+            var startupDeadline = DateTime.UtcNow.AddSeconds(5);
+            while (Agent.Instance.Context.Config.ConfigLastUpdated == 0 &&
+                   DateTime.UtcNow < startupDeadline)
+            {
+                await Task.Delay(100);
+            }
+
+            var previousConfigUpdatedAt = Agent.Instance.Context.Config.ConfigLastUpdated;
+            Assert.That(
+                previousConfigUpdatedAt,
+                Is.GreaterThan(0),
+                "The sample app must load its startup config before testing a realtime update.");
+
+            await MockServerClient.PostAsJsonAsync(
+                "/api/runtime/firewall/lists",
+                new FirewallListConfig
+                {
+                    BlockedIPAddresses =
+                    [
+                        new FirewallListConfig.IPList
+                        {
+                            Key = "realtime-test",
+                            Ips = [blockedIp],
+                            Description = "Realtime test",
+                            Source = "runtime"
+                        }
+                    ]
+                });
+
+            var deadline = DateTime.UtcNow.AddSeconds(10);
+            while (!Agent.Instance.Context.Config
+                       .GetMatchingBlockedIPListKeys(blockedIp)
+                       .Any() &&
+                   DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(100);
+            }
+
+            var currentConfigUpdatedAt = Agent.Instance.Context.Config.ConfigLastUpdated;
+            var matchingLists = Agent.Instance.Context.Config
+                .GetMatchingBlockedIPListKeys(blockedIp)
+                .ToArray();
+
+            using var request = CreateRequest(blockedIp);
+            using var response = await SampleAppClient.SendAsync(request);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    currentConfigUpdatedAt,
+                    Is.GreaterThan(previousConfigUpdatedAt),
+                    "The realtime event should advance the local config timestamp.");
+                Assert.That(
+                    matchingLists,
+                    Does.Contain("realtime-test"),
+                    "The realtime refresh should apply the updated firewall list.");
+                Assert.That(
+                    response.StatusCode,
+                    Is.EqualTo(HttpStatusCode.Forbidden),
+                    "The firewall list update should be applied through SSE well before the one-minute polling fallback.");
+            });
+        }
+
+        private void ConfigureSampleApp(IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.AddZenFirewall(options => options.UseHttpClient(MockServerClient));
+            });
+            builder.ConfigureAppConfiguration((_, _) =>
+            {
+                foreach (var envVar in SampleAppEnvironmentVariables)
+                {
+                    Environment.SetEnvironmentVariable(envVar.Key, envVar.Value);
+                }
+            });
+        }
+
+        private static HttpRequestMessage CreateRequest(string ipAddress)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "/api/pets");
+            request.Headers.Add("X-Forwarded-For", ipAddress);
+            return request;
+        }
+
+        private static async Task<long> ReadConfigUpdatedAt(
+            StreamReader reader,
+            CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                var line = await reader.ReadLineAsync(cancellationToken);
+                if (line == null)
+                {
+                    throw new EndOfStreamException("Realtime stream ended before a config update was received.");
+                }
+
+                if (!line.StartsWith("data: "))
+                {
+                    continue;
+                }
+
+                using var data = JsonDocument.Parse(line.Substring("data: ".Length));
+                return data.RootElement.GetProperty("configUpdatedAt").GetInt64();
+            }
+        }
+    }
+}

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -410,6 +410,7 @@ namespace Aikido.Zen.Test
                 .Returns<string, Func<long, Task>, CancellationToken>(
                     async (_, onUpdate, __) =>
                     {
+                        await onUpdate(100);
                         await onUpdate(200);
                         return HttpStatusCode.Unauthorized;
                     });

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -5,6 +5,7 @@ using Aikido.Zen.Core.Models.Events;
 using Aikido.Zen.Tests.Mocks;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System.Net;
 using System.Reflection;
 
 namespace Aikido.Zen.Test
@@ -19,6 +20,7 @@ namespace Aikido.Zen.Test
         public void Setup()
         {
             Environment.SetEnvironmentVariable("AIKIDO_TOKEN", "test-token");
+            Environment.SetEnvironmentVariable("AIKIDO_FEATURE_SSE", null);
             _zenApiMock = ZenApiMock.CreateMock();
             _agent = new Agent(_zenApiMock.Object);
         }
@@ -27,6 +29,7 @@ namespace Aikido.Zen.Test
         public void TearDown()
         {
             _agent.Dispose();
+            Environment.SetEnvironmentVariable("AIKIDO_FEATURE_SSE", null);
         }
 
         [Test]
@@ -344,6 +347,106 @@ namespace Aikido.Zen.Test
                 r => r.GetFirewallLists(It.IsAny<string>(), It.IsAny<CancellationToken>()),
                 Times.Once
             );
+        }
+
+        [Test]
+        public async Task Start_WhenRealtimeEnabled_AppliesNotifiedConfigAndFirewallLists()
+        {
+            Environment.SetEnvironmentVariable("AIKIDO_FEATURE_SSE", "true");
+
+            var reportingApiMock = new Mock<IReportingAPIClient>();
+            reportingApiMock
+                .Setup(api => api.ReportAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<object>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ReportingAPIResponse
+                {
+                    Success = true,
+                    ConfigUpdatedAt = 100,
+                    Endpoints = Array.Empty<EndpointConfig>()
+                });
+
+            var firewallListCalls = 0;
+            reportingApiMock
+                .Setup(api => api.GetFirewallLists(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    firewallListCalls++;
+                    return Task.FromResult(new FirewallListsAPIResponse
+                    {
+                        Success = true,
+                        BlockedIPAddresses = firewallListCalls > 1
+                            ? new[]
+                            {
+                                new FirewallListsAPIResponse.IPList
+                                {
+                                    Key = "realtime",
+                                    Ips = new[] { "203.0.113.20" }
+                                }
+                            }
+                            : Array.Empty<FirewallListsAPIResponse.IPList>()
+                    });
+                });
+
+            var runtimeApiMock = new Mock<IRuntimeAPIClient>();
+            runtimeApiMock
+                .Setup(api => api.GetConfig(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ReportingAPIResponse
+                {
+                    Success = true,
+                    ConfigUpdatedAt = 200,
+                    Endpoints = Array.Empty<EndpointConfig>()
+                });
+            runtimeApiMock
+                .Setup(api => api.SubscribeToConfigUpdates(
+                    It.IsAny<string>(),
+                    It.IsAny<Func<long, Task>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<string, Func<long, Task>, CancellationToken>(
+                    async (_, onUpdate, __) =>
+                    {
+                        await onUpdate(200);
+                        return HttpStatusCode.Unauthorized;
+                    });
+
+            _agent.Dispose();
+            _zenApiMock = ZenApiMock.CreateMock(
+                reportingApiMock.Object,
+                runtimeApiMock.Object);
+            _agent = new Agent(_zenApiMock.Object);
+
+            _agent.Start();
+
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (!_agent.Context.Config.GetMatchingBlockedIPListKeys("203.0.113.20").Any() &&
+                   DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(25);
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(_agent.Context.Config.ConfigLastUpdated, Is.EqualTo(200));
+                Assert.That(
+                    _agent.Context.Config.GetMatchingBlockedIPListKeys("203.0.113.20"),
+                    Is.EquivalentTo(new[] { "realtime" }));
+            });
+            runtimeApiMock.Verify(
+                api => api.SubscribeToConfigUpdates(
+                    "test-token",
+                    It.IsAny<Func<long, Task>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+            runtimeApiMock.Verify(
+                api => api.GetConfigLastUpdated(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Test]

--- a/Aikido.Zen.Test/AgentTests.cs
+++ b/Aikido.Zen.Test/AgentTests.cs
@@ -393,6 +393,15 @@ namespace Aikido.Zen.Test
 
             var runtimeApiMock = new Mock<IRuntimeAPIClient>();
             runtimeApiMock
+                .Setup(api => api.GetConfigLastUpdated(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ConfigLastUpdatedAPIResponse
+                {
+                    Success = true,
+                    ConfigUpdatedAt = 200
+                });
+            runtimeApiMock
                 .Setup(api => api.GetConfig(
                     It.IsAny<string>(),
                     It.IsAny<CancellationToken>()))
@@ -411,6 +420,8 @@ namespace Aikido.Zen.Test
                     async (_, onUpdate, __) =>
                     {
                         await onUpdate(100);
+                        await onUpdate(200);
+                        await onUpdate(200);
                         await onUpdate(200);
                         return HttpStatusCode.Unauthorized;
                     });
@@ -447,7 +458,67 @@ namespace Aikido.Zen.Test
                 api => api.GetConfigLastUpdated(
                     It.IsAny<string>(),
                     It.IsAny<CancellationToken>()),
-                Times.Never);
+                Times.Once);
+            runtimeApiMock.Verify(
+                api => api.GetConfig(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task Start_WhenCalledAgain_DoesNotStartSecondRealtimeListener()
+        {
+            Environment.SetEnvironmentVariable("AIKIDO_FEATURE_SSE", "true");
+
+            var reportingApiMock = new Mock<IReportingAPIClient>();
+            reportingApiMock
+                .Setup(api => api.ReportAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<object>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ReportingAPIResponse { Success = false });
+
+            var subscribed = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var runtimeApiMock = new Mock<IRuntimeAPIClient>();
+            runtimeApiMock
+                .Setup(api => api.SubscribeToConfigUpdates(
+                    It.IsAny<string>(),
+                    It.IsAny<Func<long, Task>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<string, Func<long, Task>, CancellationToken>(
+                    async (_, __, cancellationToken) =>
+                    {
+                        subscribed.TrySetResult(true);
+                        await Task.Delay(-1, cancellationToken);
+                        return HttpStatusCode.OK;
+                    });
+
+            _agent.Dispose();
+            _zenApiMock = ZenApiMock.CreateMock(
+                reportingApiMock.Object,
+                runtimeApiMock.Object);
+            _agent = new Agent(_zenApiMock.Object);
+
+            _agent.Start();
+            await subscribed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var secondStartProcessed = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _agent.Start();
+            _agent.QueueEvent(
+                "test-token",
+                Started.Create(),
+                (_, __) => secondStartProcessed.TrySetResult(true));
+            await secondStartProcessed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            runtimeApiMock.Verify(
+                api => api.SubscribeToConfigUpdates(
+                    It.IsAny<string>(),
+                    It.IsAny<Func<long, Task>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Test]

--- a/Aikido.Zen.Test/EnvironmentHelperTests.cs
+++ b/Aikido.Zen.Test/EnvironmentHelperTests.cs
@@ -178,5 +178,27 @@ namespace Aikido.Zen.Test.Helpers
                 Environment.SetEnvironmentVariable("AIKIDO_DISABLE_ENDPOINT_ROUTING_CHECK", originalValue);
             }
         }
+
+        [TestCase(null, false)]
+        [TestCase("false", false)]
+        [TestCase("true", true)]
+        [TestCase("1", true)]
+        public void RealtimeConfigUpdatesEnabled_ShouldReturnExpectedValue(string? value, bool expected)
+        {
+            var originalValue = Environment.GetEnvironmentVariable("AIKIDO_FEATURE_SSE");
+
+            try
+            {
+                Environment.SetEnvironmentVariable("AIKIDO_FEATURE_SSE", value);
+
+                Assert.That(
+                    EnvironmentHelper.RealtimeConfigUpdatesEnabled,
+                    Is.EqualTo(expected));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AIKIDO_FEATURE_SSE", originalValue);
+            }
+        }
     }
 }

--- a/Aikido.Zen.Test/RealtimeConfigUpdateListenerTests.cs
+++ b/Aikido.Zen.Test/RealtimeConfigUpdateListenerTests.cs
@@ -1,0 +1,82 @@
+using Aikido.Zen.Core.Api;
+using Aikido.Zen.Core.Realtime;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Aikido.Zen.Test
+{
+    public class RealtimeConfigUpdateListenerTests
+    {
+        [Test]
+        public async Task RunAsync_RetriesTransientFailuresAndStopsOnRejectedToken()
+        {
+            var runtimeApi = new Mock<IRuntimeAPIClient>();
+            var calls = 0;
+            runtimeApi
+                .Setup(api => api.SubscribeToConfigUpdates(
+                    It.IsAny<string>(),
+                    It.IsAny<Func<long, Task>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    calls++;
+                    return calls == 1
+                        ? Task.FromException<HttpStatusCode>(new HttpRequestException("temporary failure"))
+                        : Task.FromResult(HttpStatusCode.Unauthorized);
+                });
+
+            await RealtimeConfigUpdateListener.RunAsync(
+                runtimeApi.Object,
+                "test-token",
+                _ => Task.CompletedTask,
+                CancellationToken.None,
+                initialReconnectDelay: TimeSpan.FromMilliseconds(1));
+
+            Assert.That(calls, Is.EqualTo(2));
+        }
+
+        [Test]
+        public async Task RunAsync_ForwardsUpdatesAndStopsWhenCancelled()
+        {
+            var subscribed = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var runtimeApi = new Mock<IRuntimeAPIClient>();
+            runtimeApi
+                .Setup(api => api.SubscribeToConfigUpdates(
+                    It.IsAny<string>(),
+                    It.IsAny<Func<long, Task>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<string, Func<long, Task>, CancellationToken>(
+                    async (_, onUpdate, cancellationToken) =>
+                    {
+                        await onUpdate(321);
+                        subscribed.TrySetResult(true);
+                        await Task.Delay(-1, cancellationToken);
+                        return HttpStatusCode.OK;
+                    });
+
+            long received = 0;
+            using var cancellationSource = new CancellationTokenSource();
+            var listenerTask = RealtimeConfigUpdateListener.RunAsync(
+                runtimeApi.Object,
+                "test-token",
+                configUpdatedAt =>
+                {
+                    received = configUpdatedAt;
+                    return Task.CompletedTask;
+                },
+                cancellationSource.Token);
+
+            await subscribed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            cancellationSource.Cancel();
+            await listenerTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(received, Is.EqualTo(321));
+        }
+    }
+}

--- a/Aikido.Zen.Test/RealtimeConfigUpdateListenerTests.cs
+++ b/Aikido.Zen.Test/RealtimeConfigUpdateListenerTests.cs
@@ -32,12 +32,16 @@ namespace Aikido.Zen.Test
                         : Task.FromResult(rejectedStatus);
                 });
 
-            await RealtimeConfigUpdateListener.RunAsync(
+            var listener = new RealtimeConfigUpdateListener
+            {
+                ReconnectDelay = TimeSpan.Zero
+            };
+
+            await listener.RunAsync(
                 runtimeApi.Object,
                 "test-token",
                 _ => Task.CompletedTask,
-                CancellationToken.None,
-                initialReconnectDelay: TimeSpan.FromMilliseconds(1));
+                CancellationToken.None);
 
             Assert.That(calls, Is.EqualTo(2));
         }
@@ -64,7 +68,8 @@ namespace Aikido.Zen.Test
 
             long received = 0;
             using var cancellationSource = new CancellationTokenSource();
-            var listenerTask = RealtimeConfigUpdateListener.RunAsync(
+            var listener = new RealtimeConfigUpdateListener();
+            var listenerTask = listener.RunAsync(
                 runtimeApi.Object,
                 "test-token",
                 configUpdatedAt =>
@@ -87,6 +92,10 @@ namespace Aikido.Zen.Test
             var disconnected = new TaskCompletionSource<bool>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
             var runtimeApi = new Mock<IRuntimeAPIClient>();
+            var listener = new RealtimeConfigUpdateListener
+            {
+                ReconnectDelay = TimeSpan.FromSeconds(30)
+            };
             runtimeApi
                 .Setup(api => api.SubscribeToConfigUpdates(
                     It.IsAny<string>(),
@@ -94,28 +103,51 @@ namespace Aikido.Zen.Test
                     It.IsAny<CancellationToken>()))
                 .Returns(() =>
                 {
+                    listener.ConnectionStartedAt = DateTime.UtcNow.AddSeconds(-31);
                     disconnected.TrySetResult(true);
                     return Task.FromResult(HttpStatusCode.OK);
                 });
 
             using var cancellationSource = new CancellationTokenSource();
-            var listenerTask = RealtimeConfigUpdateListener.RunAsync(
+            var listenerTask = listener.RunAsync(
                 runtimeApi.Object,
                 "test-token",
                 _ => Task.CompletedTask,
-                cancellationSource.Token,
-                initialReconnectDelay: TimeSpan.FromSeconds(30));
+                cancellationSource.Token);
 
             await disconnected.Task.WaitAsync(TimeSpan.FromSeconds(5));
             cancellationSource.Cancel();
             await listenerTask.WaitAsync(TimeSpan.FromSeconds(5));
 
+            Assert.That(listener.ReconnectDelay, Is.EqualTo(TimeSpan.FromSeconds(5)));
             runtimeApi.Verify(
                 api => api.SubscribeToConfigUpdates(
                     It.IsAny<string>(),
                     It.IsAny<Func<long, Task>>(),
                     It.IsAny<CancellationToken>()),
                 Times.Once);
+        }
+
+        [Test]
+        public async Task RunAsync_DoesNotSubscribeWhenAlreadyCancelled()
+        {
+            var runtimeApi = new Mock<IRuntimeAPIClient>();
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            var listener = new RealtimeConfigUpdateListener();
+            await listener.RunAsync(
+                runtimeApi.Object,
+                "test-token",
+                _ => Task.CompletedTask,
+                cancellationSource.Token);
+
+            runtimeApi.Verify(
+                api => api.SubscribeToConfigUpdates(
+                    It.IsAny<string>(),
+                    It.IsAny<Func<long, Task>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
         }
     }
 }

--- a/Aikido.Zen.Test/RealtimeConfigUpdateListenerTests.cs
+++ b/Aikido.Zen.Test/RealtimeConfigUpdateListenerTests.cs
@@ -12,8 +12,10 @@ namespace Aikido.Zen.Test
 {
     public class RealtimeConfigUpdateListenerTests
     {
-        [Test]
-        public async Task RunAsync_RetriesTransientFailuresAndStopsOnRejectedToken()
+        [TestCase(HttpStatusCode.Unauthorized)]
+        [TestCase(HttpStatusCode.Forbidden)]
+        public async Task RunAsync_RetriesTransientFailuresAndStopsOnRejectedToken(
+            HttpStatusCode rejectedStatus)
         {
             var runtimeApi = new Mock<IRuntimeAPIClient>();
             var calls = 0;
@@ -27,7 +29,7 @@ namespace Aikido.Zen.Test
                     calls++;
                     return calls == 1
                         ? Task.FromException<HttpStatusCode>(new HttpRequestException("temporary failure"))
-                        : Task.FromResult(HttpStatusCode.Unauthorized);
+                        : Task.FromResult(rejectedStatus);
                 });
 
             await RealtimeConfigUpdateListener.RunAsync(
@@ -77,6 +79,43 @@ namespace Aikido.Zen.Test
             await listenerTask.WaitAsync(TimeSpan.FromSeconds(5));
 
             Assert.That(received, Is.EqualTo(321));
+        }
+
+        [Test]
+        public async Task RunAsync_StopsWhenCancelledDuringReconnectDelay()
+        {
+            var disconnected = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var runtimeApi = new Mock<IRuntimeAPIClient>();
+            runtimeApi
+                .Setup(api => api.SubscribeToConfigUpdates(
+                    It.IsAny<string>(),
+                    It.IsAny<Func<long, Task>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    disconnected.TrySetResult(true);
+                    return Task.FromResult(HttpStatusCode.OK);
+                });
+
+            using var cancellationSource = new CancellationTokenSource();
+            var listenerTask = RealtimeConfigUpdateListener.RunAsync(
+                runtimeApi.Object,
+                "test-token",
+                _ => Task.CompletedTask,
+                cancellationSource.Token,
+                initialReconnectDelay: TimeSpan.FromSeconds(30));
+
+            await disconnected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            cancellationSource.Cancel();
+            await listenerTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            runtimeApi.Verify(
+                api => api.SubscribeToConfigUpdates(
+                    It.IsAny<string>(),
+                    It.IsAny<Func<long, Task>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
         }
     }
 }

--- a/Aikido.Zen.Test/RuntimeApiClientTests.cs
+++ b/Aikido.Zen.Test/RuntimeApiClientTests.cs
@@ -191,6 +191,7 @@ namespace Aikido.Zen.Test
                 StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(
                     "\uFEFF: ping\r\n\r\n" +
+                    "retry\r\n" +
                     "event: config-updated\r\n" +
                     "data: {\r\n" +
                     "data: \"configUpdatedAt\": 123\r\n" +
@@ -208,15 +209,17 @@ namespace Aikido.Zen.Test
                 .ReturnsAsync(response);
 
             long configUpdatedAt = 0;
+            using var cancellationSource = new CancellationTokenSource();
 
             var statusCode = await _runtimeApiClient.SubscribeToConfigUpdates(
                 "test-token",
                 value =>
                 {
                     configUpdatedAt = value;
+                    cancellationSource.Cancel();
                     return Task.CompletedTask;
                 },
-                CancellationToken.None);
+                cancellationSource.Token);
 
             Assert.That(statusCode, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(configUpdatedAt, Is.EqualTo(123L));
@@ -291,6 +294,34 @@ namespace Aikido.Zen.Test
                 CancellationToken.None);
 
             Assert.That(result, Is.EqualTo(statusCode));
+        }
+
+        [Test]
+        public void WaitForLineOrTimeout_ShouldStopWhenCancelled()
+        {
+            var readTask = new TaskCompletionSource<string>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            Assert.ThrowsAsync<OperationCanceledException>(() =>
+                RuntimeAPIClient.WaitForLineOrTimeout(
+                    readTask.Task,
+                    cancellationSource.Token,
+                    TimeSpan.FromSeconds(1)));
+        }
+
+        [Test]
+        public void WaitForLineOrTimeout_ShouldThrowAfterTimeout()
+        {
+            var readTask = new TaskCompletionSource<string>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            Assert.ThrowsAsync<TimeoutException>(() =>
+                RuntimeAPIClient.WaitForLineOrTimeout(
+                    readTask.Task,
+                    CancellationToken.None,
+                    TimeSpan.Zero));
         }
 
     }

--- a/Aikido.Zen.Test/RuntimeApiClientTests.cs
+++ b/Aikido.Zen.Test/RuntimeApiClientTests.cs
@@ -1,10 +1,12 @@
 using Aikido.Zen.Core.Api;
+using Aikido.Zen.Core.Helpers;
 using Moq;
 using Moq.Protected;
 using NUnit.Framework;
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -179,6 +181,116 @@ namespace Aikido.Zen.Test
             // Assert
             Assert.That(result.Success, Is.False);
             Assert.That(result.Error, Is.EqualTo("timeout"));
+        }
+
+        [Test]
+        public async Task SubscribeToConfigUpdates_ShouldReadConfigUpdatedEvents()
+        {
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    "\uFEFF: ping\r\n\r\n" +
+                    "event: config-updated\r\n" +
+                    "data: {\r\n" +
+                    "data: \"configUpdatedAt\": 123\r\n" +
+                    "data: }\r\n\r\n",
+                    Encoding.UTF8,
+                    "text/event-stream")
+            };
+
+            _handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(response);
+
+            long configUpdatedAt = 0;
+
+            var statusCode = await _runtimeApiClient.SubscribeToConfigUpdates(
+                "test-token",
+                value =>
+                {
+                    configUpdatedAt = value;
+                    return Task.CompletedTask;
+                },
+                CancellationToken.None);
+
+            Assert.That(statusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(configUpdatedAt, Is.EqualTo(123L));
+            _handlerMock.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(request =>
+                    request.Method == HttpMethod.Get &&
+                    request.RequestUri!.AbsolutePath == "/api/runtime/stream" &&
+                    request.Headers.Authorization!.Scheme == "test-token" &&
+                    request.Headers.Accept.ToString() == "text/event-stream" &&
+                    !request.Headers.AcceptEncoding.Any() &&
+                    request.Headers.CacheControl!.NoCache &&
+                    request.Headers.GetValues("X-Agent-Platform").Single() == "dotnet" &&
+                    request.Headers.GetValues("X-Agent-Version").Single() == AgentInfoHelper.ZenVersion),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Test]
+        public async Task SubscribeToConfigUpdates_ShouldIgnoreInvalidPayloads()
+        {
+            var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    "event: config-updated\n" +
+                    "data: not-json\n\n" +
+                    "event: config-updated\n" +
+                    "data: {\"configUpdatedAt\":456}\n\n",
+                    Encoding.UTF8,
+                    "text/event-stream")
+            };
+
+            _handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(response);
+
+            long configUpdatedAt = 0;
+
+            var statusCode = await _runtimeApiClient.SubscribeToConfigUpdates(
+                "test-token",
+                value =>
+                {
+                    configUpdatedAt = value;
+                    return Task.CompletedTask;
+                },
+                CancellationToken.None);
+
+            Assert.That(statusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(configUpdatedAt, Is.EqualTo(456L));
+        }
+
+        [TestCase(HttpStatusCode.Unauthorized)]
+        [TestCase(HttpStatusCode.Forbidden)]
+        public async Task SubscribeToConfigUpdates_ShouldReturnRejectedStatus(HttpStatusCode statusCode)
+        {
+            _handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage { StatusCode = statusCode });
+
+            var result = await _runtimeApiClient.SubscribeToConfigUpdates(
+                "test-token",
+                _ => Task.CompletedTask,
+                CancellationToken.None);
+
+            Assert.That(result, Is.EqualTo(statusCode));
         }
 
     }

--- a/e2e/Aikido.Zen.Server.Mock/Controllers/RuntimeController.cs
+++ b/e2e/Aikido.Zen.Server.Mock/Controllers/RuntimeController.cs
@@ -56,7 +56,7 @@ namespace Aikido.Zen.Server.Mock.Controllers
                 var signalLock = new object();
                 var updateSignal = CreateUpdateSignal();
 
-                void OnConfigUpdated(int appId, long configUpdatedAt)
+                void OnConfigUpdated(int appId)
                 {
                     if (appId != appModel!.Id)
                     {
@@ -65,7 +65,7 @@ namespace Aikido.Zen.Server.Mock.Controllers
 
                     lock (signalLock)
                     {
-                        updateSignal.TrySetResult(configUpdatedAt);
+                        updateSignal.TrySetResult(_configService.GetConfigUpdatedAt(appId));
                     }
                 }
 

--- a/e2e/Aikido.Zen.Server.Mock/Controllers/RuntimeController.cs
+++ b/e2e/Aikido.Zen.Server.Mock/Controllers/RuntimeController.cs
@@ -3,6 +3,7 @@ using Aikido.Zen.Server.Mock.Models;
 using Aikido.Zen.Server.Mock.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using System.Text.Json;
 
 namespace Aikido.Zen.Server.Mock.Controllers
 {
@@ -36,6 +37,81 @@ namespace Aikido.Zen.Server.Mock.Controllers
                 var appModel = context.Items["app"] as AppModel;
                 _configService.UpdateConfig(appModel!.Id, config);
                 return Results.Json(new { success = true });
+            }).AddEndpointFilter<AuthFilter>();
+
+            app.MapGet("/api/runtime/stream", async Task<IResult> (HttpContext context) =>
+            {
+                var appModel = context.Items["app"] as AppModel;
+                var cancellationToken = context.RequestAborted;
+                var signalLock = new object();
+                var updateSignal = CreateUpdateSignal();
+
+                void OnConfigUpdated(int appId, long configUpdatedAt)
+                {
+                    if (appId != appModel!.Id)
+                    {
+                        return;
+                    }
+
+                    lock (signalLock)
+                    {
+                        updateSignal.TrySetResult(configUpdatedAt);
+                    }
+                }
+
+                context.Response.ContentType = "text/event-stream";
+                context.Response.Headers.CacheControl = "no-cache";
+                _configService.ConfigUpdated += OnConfigUpdated;
+
+                try
+                {
+                    await WriteConfigUpdate(
+                        context,
+                        _configService.GetConfigUpdatedAt(appModel!.Id),
+                        cancellationToken);
+
+                    while (!cancellationToken.IsCancellationRequested)
+                    {
+                        TaskCompletionSource<long> currentSignal;
+                        lock (signalLock)
+                        {
+                            currentSignal = updateSignal;
+                        }
+
+                        var pingTask = Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+                        var completedTask = await Task.WhenAny(currentSignal.Task, pingTask);
+
+                        if (completedTask == currentSignal.Task)
+                        {
+                            var configUpdatedAt = await currentSignal.Task;
+                            lock (signalLock)
+                            {
+                                if (ReferenceEquals(updateSignal, currentSignal))
+                                {
+                                    updateSignal = CreateUpdateSignal();
+                                }
+                            }
+
+                            await WriteConfigUpdate(context, configUpdatedAt, cancellationToken);
+                        }
+                        else
+                        {
+                            await pingTask;
+                            await context.Response.WriteAsync(": ping\n\n", cancellationToken);
+                            await context.Response.Body.FlushAsync(cancellationToken);
+                        }
+                    }
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // The client closed the stream.
+                }
+                finally
+                {
+                    _configService.ConfigUpdated -= OnConfigUpdated;
+                }
+
+                return Results.Empty;
             }).AddEndpointFilter<AuthFilter>();
 
             // Events endpoints
@@ -115,6 +191,24 @@ namespace Aikido.Zen.Server.Mock.Controllers
                 var token = _appService.CreateApp();
                 return Results.Json(new { token });
             });
+        }
+
+        private static TaskCompletionSource<long> CreateUpdateSignal()
+        {
+            return new TaskCompletionSource<long>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        private static async Task WriteConfigUpdate(
+            HttpContext context,
+            long configUpdatedAt,
+            CancellationToken cancellationToken)
+        {
+            var data = JsonSerializer.Serialize(new { configUpdatedAt });
+            await context.Response.WriteAsync(
+                $"event: config-updated\ndata: {data}\n\n",
+                cancellationToken);
+            await context.Response.Body.FlushAsync(cancellationToken);
         }
     }
 }

--- a/e2e/Aikido.Zen.Server.Mock/Controllers/RuntimeController.cs
+++ b/e2e/Aikido.Zen.Server.Mock/Controllers/RuntimeController.cs
@@ -26,6 +26,16 @@ namespace Aikido.Zen.Server.Mock.Controllers
         public void ConfigureEndpoints(WebApplication app)
         {
             // Config endpoints
+            app.MapGet("/config", (HttpContext context) =>
+            {
+                var appModel = context.Items["app"] as AppModel;
+                return Results.Json(new
+                {
+                    success = true,
+                    configUpdatedAt = _configService.GetConfigUpdatedAt(appModel!.Id)
+                });
+            }).AddEndpointFilter<AuthFilter>();
+
             app.MapGet("/api/runtime/config", async (HttpContext context) =>
             {
                 var appModel = context.Items["app"] as AppModel;

--- a/e2e/Aikido.Zen.Server.Mock/Models/FirewallListConfig.cs
+++ b/e2e/Aikido.Zen.Server.Mock/Models/FirewallListConfig.cs
@@ -36,6 +36,11 @@ namespace Aikido.Zen.Server.Mock.Models
         public class IPList
         {
             /// <summary>
+            /// Gets or sets the stable identifier of the IP list.
+            /// </summary>
+            public string Key { get; set; }
+
+            /// <summary>
             /// Gets or sets the source of the IP list.
             /// </summary>
             public string Source { get; set; }

--- a/e2e/Aikido.Zen.Server.Mock/Services/ConfigService.cs
+++ b/e2e/Aikido.Zen.Server.Mock/Services/ConfigService.cs
@@ -10,6 +10,8 @@ public class ConfigService
     private readonly Dictionary<int, string> _blockedUserAgents = new();
     private readonly Dictionary<int, IEnumerable<FirewallListConfig.IPList>> _allowedIps = new();
 
+    public event Action<int, long>? ConfigUpdated;
+
     public Dictionary<string, object> GetConfig(int appId)
     {
         if (!_configs.TryGetValue(appId, out var config))
@@ -34,7 +36,7 @@ public class ConfigService
                 : value;
         }
 
-        _configs[appId]["configUpdatedAt"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        UpdateConfigTimestamp(appId);
     }
 
     public void UpdateBlockedIps(int appId, List<FirewallListConfig.IPList> ips)
@@ -88,12 +90,21 @@ public class ConfigService
         };
     }
 
+    public long GetConfigUpdatedAt(int appId)
+    {
+        var config = GetConfig(appId);
+        return Convert.ToInt64(config["configUpdatedAt"]);
+    }
+
     private void UpdateConfigTimestamp(int appId)
     {
-        if (_configs.TryGetValue(appId, out var config))
-        {
-            config["configUpdatedAt"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        }
+        var config = GetConfig(appId);
+        var currentTimestamp = Convert.ToInt64(config["configUpdatedAt"]);
+        var timestamp = Math.Max(
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            currentTimestamp + 1);
+        config["configUpdatedAt"] = timestamp;
+        ConfigUpdated?.Invoke(appId, timestamp);
     }
 
     private static List<string> _largeBlockedIpList = Enumerable.Range(0, 1000)

--- a/e2e/Aikido.Zen.Server.Mock/Services/ConfigService.cs
+++ b/e2e/Aikido.Zen.Server.Mock/Services/ConfigService.cs
@@ -10,7 +10,7 @@ public class ConfigService
     private readonly Dictionary<int, string> _blockedUserAgents = new();
     private readonly Dictionary<int, IEnumerable<FirewallListConfig.IPList>> _allowedIps = new();
 
-    public event Action<int, long>? ConfigUpdated;
+    public event Action<int>? ConfigUpdated;
 
     public Dictionary<string, object> GetConfig(int appId)
     {
@@ -99,9 +99,8 @@ public class ConfigService
     private void UpdateConfigTimestamp(int appId)
     {
         var config = GetConfig(appId);
-        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        config["configUpdatedAt"] = timestamp;
-        ConfigUpdated?.Invoke(appId, timestamp);
+        config["configUpdatedAt"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        ConfigUpdated?.Invoke(appId);
     }
 
     private static List<string> _largeBlockedIpList = Enumerable.Range(0, 1000)

--- a/e2e/Aikido.Zen.Server.Mock/Services/ConfigService.cs
+++ b/e2e/Aikido.Zen.Server.Mock/Services/ConfigService.cs
@@ -99,10 +99,7 @@ public class ConfigService
     private void UpdateConfigTimestamp(int appId)
     {
         var config = GetConfig(appId);
-        var currentTimestamp = Convert.ToInt64(config["configUpdatedAt"]);
-        var timestamp = Math.Max(
-            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            currentTimestamp + 1);
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         config["configUpdatedAt"] = timestamp;
         ConfigUpdated?.Invoke(appId, timestamp);
     }


### PR DESCRIPTION
## Summary

- add feature-gated realtime configuration notifications over server-sent events
- refresh configuration and firewall lists when a newer `config-updated` event arrives
- reconnect with bounded exponential backoff and jitter, while stopping on rejected credentials
- identify SSE connections with the .NET agent platform and version headers
- add unit and end-to-end coverage, including the mock runtime SSE stream

## Why

Configuration changes currently depend on the periodic polling interval. The realtime stream lets an enabled agent apply newer configuration promptly while retaining the existing one-minute polling path as a fallback.

The feature is disabled by default and can be enabled with `AIKIDO_FEATURE_SSE`.

## Validation

- `dotnet cake build.cake --target=DownloadLibraries --downloadRetries=3 --downloadRetryDelaySeconds=1`
- `dotnet test Aikido.Zen.Test/Aikido.Zen.Tests.csproj --configuration Release --tl:off` - 1,440 passed
- `dotnet test Aikido.Zen.Test.End2End/Aikido.Zen.Test.End2End.csproj --configuration Release --tl:off --filter "FullyQualifiedName~RealtimeConfigUpdateTests"` - 2 passed
- `dotnet build Aikido.Zen.DotNetFramework/Aikido.Zen.DotNetFramework.csproj --configuration Release --no-restore --tl:off` - net461, net47, and net48 succeeded

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 4 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added SSE-based realtime configuration updates with reconnect and parsing


<sup>[More info](https://app.aikido.dev/featurebranch/scan/152658383?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->