### PR TITLE
Report agent target framework

### DIFF
--- a/Aikido.Zen.Core/Helpers/AgentInfoHelper.cs
+++ b/Aikido.Zen.Core/Helpers/AgentInfoHelper.cs
@@ -1,8 +1,10 @@
 using Aikido.Zen.Core.Models;
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 [assembly: InternalsVisibleTo("Aikido.Zen.Tests")]
 [assembly: InternalsVisibleTo("Aikido.Zen.DotNetCore")]
 [assembly: InternalsVisibleTo("Aikido.Zen.DotNetFramework")]
@@ -59,9 +61,12 @@ namespace Aikido.Zen.Core.Helpers
             return version;
         }
 
-        internal static void SetVersion(string version)
+        internal static void SetAgentAssembly(Assembly assembly)
         {
-            _cachedAgentInfo.Version = CleanVersion(version);
+            _cachedAgentInfo.Version = CleanVersion(assembly.GetName().Version.ToString());
+            _cachedAgentInfo.Platform.TargetFramework = assembly
+                .GetCustomAttribute<TargetFrameworkAttribute>()
+                ?.FrameworkName;
         }
     }
 }

--- a/Aikido.Zen.Core/Helpers/AgentInfoHelper.cs
+++ b/Aikido.Zen.Core/Helpers/AgentInfoHelper.cs
@@ -63,10 +63,17 @@ namespace Aikido.Zen.Core.Helpers
 
         internal static void SetAgentAssembly(Assembly assembly)
         {
+            if (assembly == null)
+            {
+                _cachedAgentInfo.Version = string.Empty;
+                _cachedAgentInfo.Platform.TargetFramework = string.Empty;
+                return;
+            }
+
             _cachedAgentInfo.Version = CleanVersion(assembly.GetName().Version.ToString());
             _cachedAgentInfo.Platform.TargetFramework = assembly
                 .GetCustomAttribute<TargetFrameworkAttribute>()
-                ?.FrameworkName;
+                ?.FrameworkName ?? string.Empty;
         }
     }
 }

--- a/Aikido.Zen.Core/Helpers/AgentInfoHelper.cs
+++ b/Aikido.Zen.Core/Helpers/AgentInfoHelper.cs
@@ -66,14 +66,17 @@ namespace Aikido.Zen.Core.Helpers
             if (assembly == null)
             {
                 _cachedAgentInfo.Version = string.Empty;
-                _cachedAgentInfo.Platform.TargetFramework = string.Empty;
+                _cachedAgentInfo.Platform.Version = string.Empty;
                 return;
             }
 
             _cachedAgentInfo.Version = CleanVersion(assembly.GetName().Version.ToString());
-            _cachedAgentInfo.Platform.TargetFramework = assembly
+            var targetFramework = assembly
                 .GetCustomAttribute<TargetFrameworkAttribute>()
-                ?.FrameworkName ?? string.Empty;
+                ?.FrameworkName;
+            _cachedAgentInfo.Platform.Version = string.IsNullOrEmpty(targetFramework)
+                ? Environment.Version.ToString()
+                : $"{Environment.Version} ({targetFramework})";
         }
     }
 }

--- a/Aikido.Zen.Core/Models/Platform.cs
+++ b/Aikido.Zen.Core/Models/Platform.cs
@@ -3,7 +3,6 @@ namespace Aikido.Zen.Core.Models {
     public class Platform
     {
         public string Version { get; set; }
-        public string TargetFramework { get; set; }
         public string Arch { get; set; }
     }
 }

--- a/Aikido.Zen.Core/Models/Platform.cs
+++ b/Aikido.Zen.Core/Models/Platform.cs
@@ -3,6 +3,7 @@ namespace Aikido.Zen.Core.Models {
     public class Platform
     {
         public string Version { get; set; }
+        public string TargetFramework { get; set; }
         public string Arch { get; set; }
     }
 }

--- a/Aikido.Zen.DotNetCore/Zen.cs
+++ b/Aikido.Zen.DotNetCore/Zen.cs
@@ -39,7 +39,7 @@ namespace Aikido.Zen.DotNetCore
                 throw new InvalidOperationException("Aikido.Zen.DotNetCore.Zen.Initialize must be called before Zen.Start().");
             }
 
-            AgentInfoHelper.SetVersion(typeof(Zen).Assembly.GetName().Version.ToString());
+            AgentInfoHelper.SetAgentAssembly(typeof(Zen).Assembly);
             var options = _serviceProvider.GetRequiredService<IOptions<AikidoOptions>>();
 
             if (!string.IsNullOrEmpty(options?.Value?.AikidoToken))

--- a/Aikido.Zen.DotNetFramework/Zen.cs
+++ b/Aikido.Zen.DotNetFramework/Zen.cs
@@ -41,7 +41,7 @@ namespace Aikido.Zen.DotNetFramework
             }
 
             // set zen version
-            AgentInfoHelper.SetVersion(typeof(Zen).Assembly.GetName().Version.ToString());
+            AgentInfoHelper.SetAgentAssembly(typeof(Zen).Assembly);
             // patch the sinks
             CorePatcher.PatchSinks(GetContext);
             // setup the agent

--- a/Aikido.Zen.Test/AgentInfoHelperTests.cs
+++ b/Aikido.Zen.Test/AgentInfoHelperTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Aikido.Zen.Core.Helpers;
 
 namespace Aikido.Zen.Test.Helpers
@@ -50,6 +51,21 @@ namespace Aikido.Zen.Test.Helpers
                 Assert.That(agentInfo.Platform.Version, Is.EqualTo(Environment.Version.ToString()));
                 Assert.That(agentInfo.Platform.Arch, Is.EqualTo(RuntimeInformation.ProcessArchitecture.ToString()));
             });
+        }
+
+        [Test]
+        public void SetAgentAssembly_ShouldSetAgentTargetFramework()
+        {
+            var assembly = typeof(AgentInfoHelperTests).Assembly;
+            var expectedTargetFramework = assembly
+                .GetCustomAttributes(typeof(TargetFrameworkAttribute), false)
+                .Cast<TargetFrameworkAttribute>()
+                .Single()
+                .FrameworkName;
+
+            AgentInfoHelper.SetAgentAssembly(assembly);
+
+            Assert.That(AgentInfoHelper.GetInfo().Platform.TargetFramework, Is.EqualTo(expectedTargetFramework));
         }
 
         [Test]

--- a/Aikido.Zen.Test/AgentInfoHelperTests.cs
+++ b/Aikido.Zen.Test/AgentInfoHelperTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Aikido.Zen.Core.Helpers;
@@ -66,6 +68,28 @@ namespace Aikido.Zen.Test.Helpers
             AgentInfoHelper.SetAgentAssembly(assembly);
 
             Assert.That(AgentInfoHelper.GetInfo().Platform.TargetFramework, Is.EqualTo(expectedTargetFramework));
+        }
+
+        [Test]
+        public void SetAgentAssembly_NullAssembly_ShouldClearTargetFramework()
+        {
+            AgentInfoHelper.SetAgentAssembly(typeof(AgentInfoHelperTests).Assembly);
+
+            AgentInfoHelper.SetAgentAssembly(null!);
+
+            Assert.That(AgentInfoHelper.GetInfo().Platform.TargetFramework, Is.Empty);
+        }
+
+        [Test]
+        public void SetAgentAssembly_AssemblyWithoutTargetFramework_ShouldUseEmptyString()
+        {
+            var assembly = AssemblyBuilder.DefineDynamicAssembly(
+                new AssemblyName("AssemblyWithoutTargetFramework"),
+                AssemblyBuilderAccess.Run);
+
+            AgentInfoHelper.SetAgentAssembly(assembly);
+
+            Assert.That(AgentInfoHelper.GetInfo().Platform.TargetFramework, Is.Empty);
         }
 
         [Test]

--- a/Aikido.Zen.Test/AgentInfoHelperTests.cs
+++ b/Aikido.Zen.Test/AgentInfoHelperTests.cs
@@ -19,6 +19,7 @@ namespace Aikido.Zen.Test.Helpers
             _originalBlockingValue = Environment.GetEnvironmentVariable("AIKIDO_BLOCK");
             _originalLambdaValue = Environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME");
             _originalAzureValue = Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID");
+            AgentInfoHelper.SetAgentAssembly(typeof(AgentInfoHelperTests).Assembly);
         }
 
         [TearDown]
@@ -50,38 +51,34 @@ namespace Aikido.Zen.Test.Helpers
                 Assert.That(agentInfo.Os.Name, Is.EqualTo(Environment.OSVersion.Platform.ToString()));
 
                 // Platform Info
-                Assert.That(agentInfo.Platform.Version, Is.EqualTo(Environment.Version.ToString()));
+                Assert.That(agentInfo.Platform.Version, Is.EqualTo(
+                    $"{Environment.Version} ({GetTargetFrameworkName(typeof(AgentInfoHelperTests).Assembly)})"));
                 Assert.That(agentInfo.Platform.Arch, Is.EqualTo(RuntimeInformation.ProcessArchitecture.ToString()));
             });
         }
 
         [Test]
-        public void SetAgentAssembly_ShouldSetAgentTargetFramework()
+        public void SetAgentAssembly_ShouldAppendTargetFrameworkToPlatformVersion()
         {
             var assembly = typeof(AgentInfoHelperTests).Assembly;
-            var expectedTargetFramework = assembly
-                .GetCustomAttributes(typeof(TargetFrameworkAttribute), false)
-                .Cast<TargetFrameworkAttribute>()
-                .Single()
-                .FrameworkName;
+            var expectedPlatformVersion = $"{Environment.Version} ({GetTargetFrameworkName(assembly)})";
 
             AgentInfoHelper.SetAgentAssembly(assembly);
+            AgentInfoHelper.SetAgentAssembly(assembly);
 
-            Assert.That(AgentInfoHelper.GetInfo().Platform.TargetFramework, Is.EqualTo(expectedTargetFramework));
+            Assert.That(AgentInfoHelper.GetInfo().Platform.Version, Is.EqualTo(expectedPlatformVersion));
         }
 
         [Test]
-        public void SetAgentAssembly_NullAssembly_ShouldClearTargetFramework()
+        public void SetAgentAssembly_NullAssembly_ShouldClearPlatformVersion()
         {
-            AgentInfoHelper.SetAgentAssembly(typeof(AgentInfoHelperTests).Assembly);
-
             AgentInfoHelper.SetAgentAssembly(null!);
 
-            Assert.That(AgentInfoHelper.GetInfo().Platform.TargetFramework, Is.Empty);
+            Assert.That(AgentInfoHelper.GetInfo().Platform.Version, Is.Empty);
         }
 
         [Test]
-        public void SetAgentAssembly_AssemblyWithoutTargetFramework_ShouldUseEmptyString()
+        public void SetAgentAssembly_AssemblyWithoutTargetFramework_ShouldKeepRuntimeVersion()
         {
             var assembly = AssemblyBuilder.DefineDynamicAssembly(
                 new AssemblyName("AssemblyWithoutTargetFramework"),
@@ -89,7 +86,7 @@ namespace Aikido.Zen.Test.Helpers
 
             AgentInfoHelper.SetAgentAssembly(assembly);
 
-            Assert.That(AgentInfoHelper.GetInfo().Platform.TargetFramework, Is.Empty);
+            Assert.That(AgentInfoHelper.GetInfo().Platform.Version, Is.EqualTo(Environment.Version.ToString()));
         }
 
         [Test]
@@ -170,6 +167,15 @@ namespace Aikido.Zen.Test.Helpers
             {
                 Environment.SetEnvironmentVariable(variable, value);
             }
+        }
+
+        private static string GetTargetFrameworkName(Assembly assembly)
+        {
+            return assembly
+                .GetCustomAttributes(typeof(TargetFrameworkAttribute), false)
+                .Cast<TargetFrameworkAttribute>()
+                .Single()
+                .FrameworkName;
         }
 
         [Test]


### PR DESCRIPTION
## Summary

- append the loaded firewall assembly target framework to the existing `agent.platform.version` value
- format the value as `<runtime version> (<target framework>)`
- keep `agent.version` unchanged as the firewall package version
- add no new payload field, so the existing persisted `platform_version` captures the information
- use one `SetAgentAssembly(Assembly)` method from both agent entry points

## Why

`Environment.Version` reports the CLR/runtime version. On .NET Framework 4.6 and later it collapses to `4.0.30319.42000`, so current telemetry cannot distinguish customers using the `net461`, `net47`, or `net48` firewall builds.

Reading `TargetFrameworkAttribute` from the loaded firewall assembly identifies the asset selected by NuGet. Appending it to the existing platform version also makes it available through the platform's existing `platform_version` persistence.

## Impact

The runtime-event schema remains unchanged. Example values:

- .NET Framework 4.6.1: `4.0.30319.42000 (.NETFramework,Version=v4.6.1)`
- .NET 8: `8.0.x (.NETCoreApp,Version=v8.0)`

If the assembly has no `TargetFrameworkAttribute`, the original runtime version is retained.

## Validation

- focused `AgentInfoHelperTests`: 12 passed
- full `Aikido.Zen.Tests` suite: 1,449 passed
- repeated initialization covered to prevent appending the target framework twice

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Appended assembly TargetFrameworkAttribute to platform version reporting string
* Handled missing assembly metadata by clearing version and platform fields

**🔧 Refactors**
* Replaced SetVersion calls with SetAgentAssembly(Assembly) in DotNetCore and DotNetFramework entrypoints


<sup>[More info](https://app.aikido.dev/featurebranch/scan/152720906?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->