### PR TITLE
Make .NET Framework user tracking opt-in

### DIFF
--- a/Aikido.Zen.DotNetFramework/Zen.cs
+++ b/Aikido.Zen.DotNetFramework/Zen.cs
@@ -60,11 +60,8 @@ namespace Aikido.Zen.DotNetFramework
             EnvironmentHelper.ReportValues();
         }
 
-        internal static Func<HttpContext, User> SetUserAction { get; set; } = (context) => !string.IsNullOrEmpty(context.User.Identity?.Name)
-            // if we have an identity, set the user to that identity automatically
-            ? new User(context.User.Identity.Name, context.User.Identity.Name)
-            // otherwise, return null
-            : null;
+        // User tracking is opt-in. Do not infer an identity from HttpContext.
+        internal static Func<HttpContext, User> SetUserAction { get; set; } = _ => null;
 
         internal static Func<HttpContext, string> SetRateLimitGroupAction { get; set; } = _ => string.Empty;
 

--- a/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
+++ b/Aikido.Zen.Tests.DotNetFramework/ContextModuleTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Principal;
 using System.Web;
 using System.Web.Routing;
 using Aikido.Zen.Core;
@@ -273,6 +274,21 @@ namespace Aikido.Zen.Tests.DotNetFramework
             Assert.That(result["Accept[1]"], Is.EqualTo("application/json"));
             Assert.That(result.ContainsKey("Accept[2]"), Is.True);
             Assert.That(result["Accept[2]"], Is.EqualTo("application/xml"));
+        }
+
+        [Test]
+        public void SetUserAction_DoesNotTrackAuthenticatedPrincipalByDefault()
+        {
+            var httpContext = new HttpContext(
+                new HttpRequest(string.Empty, "http://test.local/api/test", string.Empty),
+                new HttpResponse(new StringWriter()))
+            {
+                User = new GenericPrincipal(new GenericIdentity("authenticated-user"), Array.Empty<string>())
+            };
+
+            var user = Aikido.Zen.DotNetFramework.Zen.SetUserAction(httpContext);
+
+            Assert.That(user, Is.Null);
         }
 
         [Test]

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ using Microsoft.AspNet.Identity;
 
 Ensure that your project runs on .NET Framework 4.6 or higher.
 
+Zen does not collect identities automatically. User tracking is enabled only when you call `Zen.SetUser`.
+
 - Install the package from NuGet.
 
 If your .NET Framework project uses SDK-style `PackageReference`, run:

--- a/docs/user.md
+++ b/docs/user.md
@@ -1,5 +1,7 @@
 # Setting the current user
 
+Zen does not collect identities automatically. User tracking is enabled only when you call `Zen.SetUser`.
+
 ## .NET Core
 
 To set the current user, you can use the `Zen.SetUser` method in your middleware:


### PR DESCRIPTION
## Summary

- stop deriving a user automatically from `HttpContext.User.Identity.Name` in the .NET Framework SDK
- preserve explicit user tracking through `Zen.SetUser(...)`
- add regression coverage using an authenticated principal
- document that identity collection is opt-in

## Why

The documented integration requires applications to call `Zen.SetUser(...)`, but the .NET Framework SDK installed a default callback that read `HttpContext.User.Identity.Name`. This caused authenticated identities to be collected even when applications never opted into user tracking.

## Impact

Applications that do not call `Zen.SetUser(...)` will no longer report user identities. User-based blocking and per-user rate limiting continue to work for applications that explicitly configure a user; otherwise rate limiting falls back to IP-based behavior.

## Validation

- regression test source compiled against the .NET Framework assemblies
- `git diff --check` passed
- the full .NET Framework test matrix is left to Windows CI because the local macOS/Mono environment cannot run the repository's authoritative Framework build


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Stopped auto-deriving user from HttpContext; made user tracking opt-in

**📚 Documentation**
* Updated code comment to document identity collection is opt-in


<sup>[More info](https://app.aikido.dev/featurebranch/scan/154056500?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->