### PR TITLE
Remove separate realtime endpoint

### DIFF
--- a/Aikido.Zen.Core/Api/Runtime.cs
+++ b/Aikido.Zen.Core/Api/Runtime.cs
@@ -25,7 +25,7 @@ namespace Aikido.Zen.Core.Api
         {
             try
             {
-                var request = APIHelper.CreateRequest(token, new Uri(EnvironmentHelper.AikidoRealtimeUrl), "config", HttpMethod.Get);
+                var request = APIHelper.CreateRequest(token, new Uri(EnvironmentHelper.AikidoUrl), "config", HttpMethod.Get);
                 var response = await _httpClient.SendAsync(request, cancellationToken);
                 return APIHelper.ToAPIResponse<ConfigLastUpdatedAPIResponse>(response);
             }
@@ -68,7 +68,7 @@ namespace Aikido.Zen.Core.Api
         {
             using (var request = APIHelper.CreateRequest(
                 token,
-                new Uri(EnvironmentHelper.AikidoRealtimeUrl),
+                new Uri(EnvironmentHelper.AikidoUrl),
                 "/api/runtime/stream",
                 HttpMethod.Get))
             {

--- a/Aikido.Zen.Core/Helpers/EnvironmentHelper.cs
+++ b/Aikido.Zen.Core/Helpers/EnvironmentHelper.cs
@@ -28,11 +28,6 @@ namespace Aikido.Zen.Core.Helpers
         public static string AikidoUrl => Environment.GetEnvironmentVariable("AIKIDO_ENDPOINT") ?? GetAikidoUrlFromToken(Token);
 
         /// <summary>
-        /// Gets the Aikido real-time URL from the environment variables or derives it from the token's region.
-        /// </summary>
-        public static string AikidoRealtimeUrl => Environment.GetEnvironmentVariable("AIKIDO_REALTIME_ENDPOINT") ?? GetAikidoUrlFromToken(Token);
-
-        /// <summary>
         /// Determines if the system is in debugging mode by checking the environment variable.
         /// </summary>
         public static bool IsDebugging => GetBooleanValue("AIKIDO_DEBUG");
@@ -139,10 +134,6 @@ namespace Aikido.Zen.Core.Helpers
             if (string.IsNullOrEmpty(AikidoUrl))
             {
                 LogHelper.InfoLog(Agent.Logger, "Aikido URL not set, Zen will not report any events and receive no configuration updates.");
-            }
-            if (string.IsNullOrEmpty(AikidoRealtimeUrl))
-            {
-                LogHelper.InfoLog(Agent.Logger, "Aikido realtime URL not set");
             }
             if (DryMode)
             {

--- a/Aikido.Zen.Test.End2End/DataRegionEndpointEnd2EndTests.cs
+++ b/Aikido.Zen.Test.End2End/DataRegionEndpointEnd2EndTests.cs
@@ -30,7 +30,6 @@ public class DataRegionEndpointEnd2EndTests
     {
         CaptureAndSetEnvironment("AIKIDO_TOKEN", RegionToken);
         CaptureAndSetEnvironment("AIKIDO_ENDPOINT", null);
-        CaptureAndSetEnvironment("AIKIDO_REALTIME_ENDPOINT", null);
         CaptureAndSetEnvironment("AIKIDO_BLOCK", "false");
         CaptureAndSetEnvironment("AIKIDO_DISABLE", null);
 
@@ -63,8 +62,6 @@ public class DataRegionEndpointEnd2EndTests
     [Test, NonParallelizable]
     public async Task StartupReporting_ShouldUseRegionSpecificGuardEndpoint_WhenEndpointIsNotSet()
     {
-        Assert.That(EnvironmentHelper.AikidoRealtimeUrl, Is.EqualTo("https://guard.us.aikido.dev"));
-
         _sampleAppClient = CreateSampleAppClient();
 
         using var response = await _sampleAppClient.GetAsync("/health");

--- a/Aikido.Zen.Test.End2End/WebApplicationTestBase.cs
+++ b/Aikido.Zen.Test.End2End/WebApplicationTestBase.cs
@@ -67,7 +67,6 @@ namespace Aikido.Zen.Test.End2End
             SampleAppEnvironmentVariables["AIKIDO_TOKEN"] = MockServerToken;
             // set the base url for the mock server
             SampleAppEnvironmentVariables["AIKIDO_ENDPOINT"] = $"http://localhost:{MockServerPort}";
-            SampleAppEnvironmentVariables["AIKIDO_REALTIME_ENDPOINT"] = $"http://localhost:{MockServerPort}";
         }
 
         [OneTimeTearDown]

--- a/Aikido.Zen.Test/EnvironmentHelperTests.cs
+++ b/Aikido.Zen.Test/EnvironmentHelperTests.cs
@@ -119,34 +119,6 @@ namespace Aikido.Zen.Test.Helpers
         }
 
         [Test]
-        public void AikidoRealtimeUrl_ShouldReturnExpectedValue_WhenEnvironmentVariableIsSet()
-        {
-            // Arrange
-            Environment.SetEnvironmentVariable("AIKIDO_REALTIME_ENDPOINT", "https://custom-realtime.aikido.dev");
-
-            // Act
-            var url = EnvironmentHelper.AikidoRealtimeUrl;
-
-            // Assert
-            Assert.That(url, Is.EqualTo("https://custom-realtime.aikido.dev"));
-        }
-
-        [TestCase("AIK_RUNTIME_1_2_US_random", "https://guard.us.aikido.dev")]
-        [TestCase("AIK_RUNTIME_1_2_ME_random", "https://guard.me.aikido.dev")]
-        [TestCase("AIK_RUNTIME_1_2_AU_random", "https://guard.au.aikido.dev")]
-        [TestCase("AIK_RUNTIME_1_2_EU_random", "https://guard.aikido.dev")]
-        [TestCase("AIK_RUNTIME_1_2_random", "https://guard.aikido.dev")]
-        public void AikidoRealtimeUrl_ShouldBeDerivedFromTokenRegion_WhenEnvironmentVariableIsNotSet(string token, string expectedUrl)
-        {
-            Environment.SetEnvironmentVariable("AIKIDO_REALTIME_ENDPOINT", null);
-            Environment.SetEnvironmentVariable("AIKIDO_TOKEN", token);
-
-            var url = EnvironmentHelper.AikidoRealtimeUrl;
-
-            Assert.That(url, Is.EqualTo(expectedUrl));
-        }
-
-        [Test]
         public void BlockInvalidSql_ShouldReturnFalse_WhenEnvironmentVariableIsNotSet()
         {
             // Arrange

--- a/Aikido.Zen.Test/OutboundRequestSinkPublicTests.cs
+++ b/Aikido.Zen.Test/OutboundRequestSinkPublicTests.cs
@@ -30,7 +30,6 @@ namespace Aikido.Zen.Test
             Environment.SetEnvironmentVariable("AIKIDO_TOKEN", "test-token");
             Environment.SetEnvironmentVariable("AIKIDO_TRUST_PROXY", "true");
             Environment.SetEnvironmentVariable("AIKIDO_ENDPOINT", "http://localhost:3000");
-            Environment.SetEnvironmentVariable("AIKIDO_REALTIME_ENDPOINT", "http://localhost:3001");
             Environment.SetEnvironmentVariable("AIKIDO_BLOCK", null);
 
             _reportingApiMock = new Mock<IReportingAPIClient>();

--- a/Aikido.Zen.Test/OutboundRequestSinkResolvedAddressTests.cs
+++ b/Aikido.Zen.Test/OutboundRequestSinkResolvedAddressTests.cs
@@ -30,7 +30,6 @@ namespace Aikido.Zen.Test
             Environment.SetEnvironmentVariable("AIKIDO_TOKEN", "test-token");
             Environment.SetEnvironmentVariable("AIKIDO_TRUST_PROXY", "true");
             Environment.SetEnvironmentVariable("AIKIDO_ENDPOINT", "http://localhost:3000");
-            Environment.SetEnvironmentVariable("AIKIDO_REALTIME_ENDPOINT", "http://localhost:3001");
             Environment.SetEnvironmentVariable("AIKIDO_BLOCK", null);
 
             _reportingApiMock = new Mock<IReportingAPIClient>();

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -23,13 +23,9 @@ export default function () {
         console.error("::error::APP_URL environment variable is not set.");
         throw new Error("APP_URL environment variable is not set.");
     }
-    if (!__ENV.AIKIDO_ENDPOINT || !__ENV.AIKIDO_REALTIME_ENDPOINT) {
-        console.error(
-            "::error::AIKIDO_ENDPOINT or AIKIDO_REALTIME_ENDPOINT environment variable is not set."
-        );
-        throw new Error(
-            "AIKIDO_ENDPOINT or AIKIDO_REALTIME_ENDPOINT environment variable is not set."
-        );
+    if (!__ENV.AIKIDO_ENDPOINT) {
+        console.error("::error::AIKIDO_ENDPOINT environment variable is not set.");
+        throw new Error("AIKIDO_ENDPOINT environment variable is not set.");
     }
     // log the env variables that start with AIKIDO
     console.log("AIKIDO_DISABLE =", __ENV.AIKIDO_DISABLE);


### PR DESCRIPTION
## Summary

- remove `AIKIDO_REALTIME_ENDPOINT` and the separate `AikidoRealtimeUrl` helper
- route configuration polling and realtime SSE through `AikidoUrl`
- use `AIKIDO_ENDPOINT` as the single endpoint override
- update unit tests, E2E setup, and benchmark validation

## Why

PR #367 moved realtime polling and SSE to the same token-derived regional guard hostname used by the regular runtime API. Keeping a second endpoint override would allow those requests to diverge again even though they now target the same service.

## Impact

`AIKIDO_REALTIME_ENDPOINT` is no longer read by the .NET agent. Custom and test deployments should configure `AIKIDO_ENDPOINT`, which now controls reporting, configuration, polling, and SSE traffic.

## Validation

- `dotnet cake build.cake --target=DownloadLibraries --downloadRetries=3 --downloadRetryDelaySeconds=1`
- focused unit tests: 82 passed
- affected data-region and realtime E2E tests: 3 passed
- `git diff --check`
- confirmed no remaining `AIKIDO_REALTIME_ENDPOINT` or `AikidoRealtimeUrl` references
